### PR TITLE
Bd 28 등록 확인 UI 구현

### DIFF
--- a/Rlog.xcodeproj/project.pbxproj
+++ b/Rlog.xcodeproj/project.pbxproj
@@ -31,6 +31,9 @@
 		2D66DCDE28FD8EB300C90400 /* ScheduleUpdateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D66DCDD28FD8EB300C90400 /* ScheduleUpdateViewModel.swift */; };
 		2D66DCE028FD8ECA00C90400 /* MainTabViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D66DCDF28FD8ECA00C90400 /* MainTabViewModel.swift */; };
 		2D66DCE428FD8F1D00C90400 /* Color+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D66DCE328FD8F1D00C90400 /* Color+.swift */; };
+		2D9CE85F290029FE00C60F4C /* WorkSpaceCreateConfirmationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D9CE85E290029FE00C60F4C /* WorkSpaceCreateConfirmationView.swift */; };
+		2D9CE86129002A3B00C60F4C /* TitleSubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D9CE86029002A3B00C60F4C /* TitleSubView.swift */; };
+		2D9CE8642900338300C60F4C /* WorkSpaceInfoSubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D9CE8632900338300C60F4C /* WorkSpaceInfoSubView.swift */; };
 		C62C338C28FFCEBD00469273 /* CustomButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C62C338B28FFCEBD00469273 /* CustomButtonView.swift */; };
 		C64D97BA28FE918F004F80E7 /* Text+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C64D97B928FE918F004F80E7 /* Text+.swift */; };
 		C64D97BC28FE9197004F80E7 /* TextField+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C64D97BB28FE9197004F80E7 /* TextField+.swift */; };
@@ -68,6 +71,9 @@
 		2D66DCDD28FD8EB300C90400 /* ScheduleUpdateViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleUpdateViewModel.swift; sourceTree = "<group>"; };
 		2D66DCDF28FD8ECA00C90400 /* MainTabViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabViewModel.swift; sourceTree = "<group>"; };
 		2D66DCE328FD8F1D00C90400 /* Color+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+.swift"; sourceTree = "<group>"; };
+		2D9CE85E290029FE00C60F4C /* WorkSpaceCreateConfirmationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkSpaceCreateConfirmationView.swift; sourceTree = "<group>"; };
+		2D9CE86029002A3B00C60F4C /* TitleSubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleSubView.swift; sourceTree = "<group>"; };
+		2D9CE8632900338300C60F4C /* WorkSpaceInfoSubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkSpaceInfoSubView.swift; sourceTree = "<group>"; };
 		C62C338B28FFCEBD00469273 /* CustomButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CustomButtonView.swift; path = Rlog/View/Components/CustomButtonView.swift; sourceTree = SOURCE_ROOT; };
 		C64D97B928FE918F004F80E7 /* Text+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Text+.swift"; sourceTree = "<group>"; };
 		C64D97BB28FE9197004F80E7 /* TextField+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TextField+.swift"; sourceTree = "<group>"; };
@@ -154,9 +160,11 @@
 		2D66DCB628FD51F900C90400 /* WorkSpace */ = {
 			isa = PBXGroup;
 			children = (
+				2D9CE8622900336800C60F4C /* SubViews */,
 				2D66DCC028FD8D5100C90400 /* WorkSpaceListView.swift */,
 				2D66DCC228FD8D6100C90400 /* WorkSpaceDetailView.swift */,
 				2D66DCC428FD8D6D00C90400 /* WorkSpaceCreateView.swift */,
+				2D9CE85E290029FE00C60F4C /* WorkSpaceCreateConfirmationView.swift */,
 			);
 			path = WorkSpace;
 			sourceTree = "<group>";
@@ -229,6 +237,15 @@
 				2D66DCAC28FD4DF200C90400 /* DataModel.xcdatamodeld */,
 			);
 			path = CoreData;
+			sourceTree = "<group>";
+		};
+		2D9CE8622900336800C60F4C /* SubViews */ = {
+			isa = PBXGroup;
+			children = (
+				2D9CE86029002A3B00C60F4C /* TitleSubView.swift */,
+				2D9CE8632900338300C60F4C /* WorkSpaceInfoSubView.swift */,
+			);
+			path = SubViews;
 			sourceTree = "<group>";
 		};
 		C64D97B828FE9146004F80E7 /* Components */ = {
@@ -327,7 +344,9 @@
 				2D66DCC128FD8D5100C90400 /* WorkSpaceListView.swift in Sources */,
 				C64D97C728FE92C7004F80E7 /* DayEntity.swift in Sources */,
 				2D66DCD028FD8E1000C90400 /* ScheduleCreateViewModel.swift in Sources */,
+				2D9CE85F290029FE00C60F4C /* WorkSpaceCreateConfirmationView.swift in Sources */,
 				C62C338C28FFCEBD00469273 /* CustomButtonView.swift in Sources */,
+				2D9CE8642900338300C60F4C /* WorkSpaceInfoSubView.swift in Sources */,
 				2D66DCBB28FD8D0E00C90400 /* ScheduleListView.swift in Sources */,
 				2D66DCBF28FD8D3700C90400 /* ScheduleUpdateView.swift in Sources */,
 				C64D97C928FE92D8004F80E7 /* Tab.swift in Sources */,
@@ -336,6 +355,7 @@
 				2D66DCDA28FD8E8F00C90400 /* WorkSpaceDetailViewModel.swift in Sources */,
 				2D66DCC328FD8D6100C90400 /* WorkSpaceDetailView.swift in Sources */,
 				2D66DCAE28FD4DF200C90400 /* DataModel.xcdatamodeld in Sources */,
+				2D9CE86129002A3B00C60F4C /* TitleSubView.swift in Sources */,
 				2D66DCDE28FD8EB300C90400 /* ScheduleUpdateViewModel.swift in Sources */,
 				C64D97BE28FE919F004F80E7 /* Date+.swift in Sources */,
 				2D66DCCC28FD8DC500C90400 /* MainTabView.swift in Sources */,

--- a/Rlog/View/WorkSpace/SubViews/TitleSubView.swift
+++ b/Rlog/View/WorkSpace/SubViews/TitleSubView.swift
@@ -8,9 +8,9 @@
 import SwiftUI
 
 struct TitleSubView: View {
-    let contents: String
+    let title: String
     var body: some View {
-        Text(contents)
+        Text(title)
             .font(.title3)
             .padding(.bottom,20)
     }
@@ -18,6 +18,6 @@ struct TitleSubView: View {
 
 struct TitleSubView_Previews: PreviewProvider {
     static var previews: some View {
-        TitleSubView(contents: "test")
+        TitleSubView(title: "test")
     }
 }

--- a/Rlog/View/WorkSpace/SubViews/TitleSubView.swift
+++ b/Rlog/View/WorkSpace/SubViews/TitleSubView.swift
@@ -1,0 +1,23 @@
+//
+//  TitleSubView.swift
+//  Rlog
+//
+//  Created by 송시원 on 2022/10/19.
+//
+
+import SwiftUI
+
+struct TitleSubView: View {
+    let contents: String
+    var body: some View {
+        Text(contents)
+            .font(.title3)
+            .padding(.bottom,20)
+    }
+}
+
+struct TitleSubView_Previews: PreviewProvider {
+    static var previews: some View {
+        TitleSubView(contents: "test")
+    }
+}

--- a/Rlog/View/WorkSpace/SubViews/WorkSpaceInfoSubView.swift
+++ b/Rlog/View/WorkSpace/SubViews/WorkSpaceInfoSubView.swift
@@ -1,0 +1,24 @@
+//
+//  WorkSpaceInfoSubView.swift
+//  Rlog
+//
+//  Created by 송시원 on 2022/10/19.
+//
+
+import SwiftUI
+
+struct WorkSpaceInfoSubView: View {
+    let labelName: String
+    let content: String
+    
+    var body: some View {
+
+        VStack(alignment: .leading, spacing: 10) {
+            Text(labelName)
+                .font(.caption)
+                .foregroundColor(.fontLightGray)
+            Text(content)
+                .foregroundColor(.fontBlack)
+        }
+    }
+}

--- a/Rlog/View/WorkSpace/WorkSpaceCreateConfirmationView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceCreateConfirmationView.swift
@@ -1,0 +1,49 @@
+//
+//  WorkSpaceCreateConfirmationView.swift
+//  Rlog
+//
+//  Created by 송시원 on 2022/10/19.
+//
+
+// TODO: 네비게이션 연결, 뷰모델 연결, 고민 공유, 컨포넌트 적용
+
+import SwiftUI
+
+struct WorkSpaceCreateConfirmationView: View {
+    var body: some View {
+        // 고민: 폭이 한계까지 닿지 않아서 가운데정렬이 되는데, 컨포넌트를 가져오면 해결된다. 이럴 경우 다른 방식으로 미뤄두는게 필요할까?
+        VStack(alignment: .leading, spacing: 20) {
+            TitleSubView(contents: "새로운 아르바이트를 추가합니다.")
+            WorkSpaceInfoSubView(labelName:"근무지", content:"팍이네 팍팍 감자탕")
+            WorkSpaceInfoSubView(labelName:"시급", content:"9,250원")
+            WorkSpaceInfoSubView(labelName:"급여일", content:"매월 10일")
+            WorkSpaceInfoSubView(labelName:"주휴수당", content:"60시간 근무 시 적용")
+            WorkSpaceInfoSubView(labelName:"근무지", content:"3.3% 적용")
+            WorkTypeInfo(for: "haha")
+            Spacer()
+        }
+        .padding()
+    }
+}
+
+private extension WorkSpaceCreateConfirmationView {
+    @ViewBuilder
+    func WorkTypeInfo(for worktype: String) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("근무 유형")
+                .font(.caption)
+                .foregroundColor(.fontLightGray)
+            // 컨포넌트에 일하는 유형을 넣어준다.
+            RoundedRectangle(cornerRadius: 10)
+                .frame(height: 54)
+        }
+    }
+}
+
+struct WorkSpaceCreateConfirmationView_Previews: PreviewProvider {
+    static var previews: some View {
+        WorkSpaceCreateConfirmationView()
+    }
+}
+
+

--- a/Rlog/View/WorkSpace/WorkSpaceCreateConfirmationView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceCreateConfirmationView.swift
@@ -13,7 +13,7 @@ struct WorkSpaceCreateConfirmationView: View {
     var body: some View {
         // 고민: 폭이 한계까지 닿지 않아서 가운데정렬이 되는데, 컨포넌트를 가져오면 해결된다. 이럴 경우 다른 방식으로 미뤄두는게 필요할까?
         VStack(alignment: .leading, spacing: 20) {
-            TitleSubView(contents: "새로운 아르바이트를 추가합니다.")
+            TitleSubView(title: "새로운 아르바이트를 추가합니다.")
             WorkSpaceInfoSubView(labelName:"근무지", content:"팍이네 팍팍 감자탕")
             WorkSpaceInfoSubView(labelName:"시급", content:"9,250원")
             WorkSpaceInfoSubView(labelName:"급여일", content:"매월 10일")


### PR DESCRIPTION
# 프로젝트 이미지 
|시뮬레이터 캡쳐|피그마 파일|
|---|---|
|<img src="https://user-images.githubusercontent.com/46256034/196706767-601a591b-ec2e-4488-b8fe-c99cfb66601b.png" width="276" />|<img width="276" alt="image" src="https://user-images.githubusercontent.com/46256034/196707982-d01a590d-7df6-4329-8ab9-476b9018c8e4.png">|



## 세부 사항
- 등록 확인 유아이를 구현하였습니다.
- **네비게이션은 아직 적용하지 않았습니다.**
- 타이틀 같은 경우, 생성 과정을 반복할 것으로 생각되어 재사용 가능성을 염두에 두어 만들었습니다.
- 파일 구조를 분리하기위해 섭뷰 그룹을 두었는데 이에 대해 어떻게 생각하시는지 궁금합니다!
- 근무지 정보유아이는 반복되는 정보를 같은 패턴에 담고있어서 해당 내용을 직접 보여주는 섭뷰로 작업했습니다.
- 근무 유형의 경우, 컨포넌트를 받아서 사용할 예정이기 때문에 이 부분은 뷰빌더로 제작하였습니다.

## 기타 질문 및 특이 사항
(궁금한 사항들, 하면서 느낀 점 및 공유할 내용)
- 뷰빌더에 프로퍼티를 넣는 경우 어떤식으로 하는지 궁급합니다 @insub4067 
- 고민: 폭이 한계까지 닿지 않아서 가운데정렬이 되는데, 컨포넌트를 가져오면 해결된다. 컨포넌트에 해당하는 뷰가 무조건적으로 있는 상태로 그리게 될 텐데, 컨포넌트 말고도 다른 방식으로 VStack의 폭을 화면에 맞게 넓히는게 필요할까?
-

### 해당 뷰와 관련해서 남은 할 일
- [ ] 네비게이션 연결
- [ ] 고민을 적은 부분 공유
- [ ] 요일을 담는 컨포넌트 적용
- [ ] 뷰모델 연결

 
## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)
- [x]  필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x]  코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x]  제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x]  본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
