### PR TITLE
BD-26-근무-유형-리스트-ui-구현

### DIFF
--- a/Rlog.xcodeproj/project.pbxproj
+++ b/Rlog.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		2D66DCDE28FD8EB300C90400 /* ScheduleUpdateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D66DCDD28FD8EB300C90400 /* ScheduleUpdateViewModel.swift */; };
 		2D66DCE028FD8ECA00C90400 /* MainTabViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D66DCDF28FD8ECA00C90400 /* MainTabViewModel.swift */; };
 		2D66DCE428FD8F1D00C90400 /* Color+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D66DCE328FD8F1D00C90400 /* Color+.swift */; };
+		2D9CE86629003AA600C60F4C /* WorkSpaceCreateScheduleListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D9CE86529003AA600C60F4C /* WorkSpaceCreateScheduleListView.swift */; };
 		C62C338C28FFCEBD00469273 /* CustomButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C62C338B28FFCEBD00469273 /* CustomButtonView.swift */; };
 		C64D97BA28FE918F004F80E7 /* Text+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C64D97B928FE918F004F80E7 /* Text+.swift */; };
 		C64D97BC28FE9197004F80E7 /* TextField+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C64D97BB28FE9197004F80E7 /* TextField+.swift */; };
@@ -68,6 +69,7 @@
 		2D66DCDD28FD8EB300C90400 /* ScheduleUpdateViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleUpdateViewModel.swift; sourceTree = "<group>"; };
 		2D66DCDF28FD8ECA00C90400 /* MainTabViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabViewModel.swift; sourceTree = "<group>"; };
 		2D66DCE328FD8F1D00C90400 /* Color+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+.swift"; sourceTree = "<group>"; };
+		2D9CE86529003AA600C60F4C /* WorkSpaceCreateScheduleListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkSpaceCreateScheduleListView.swift; sourceTree = "<group>"; };
 		C62C338B28FFCEBD00469273 /* CustomButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CustomButtonView.swift; path = Rlog/View/Components/CustomButtonView.swift; sourceTree = SOURCE_ROOT; };
 		C64D97B928FE918F004F80E7 /* Text+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Text+.swift"; sourceTree = "<group>"; };
 		C64D97BB28FE9197004F80E7 /* TextField+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TextField+.swift"; sourceTree = "<group>"; };
@@ -157,6 +159,7 @@
 				2D66DCC028FD8D5100C90400 /* WorkSpaceListView.swift */,
 				2D66DCC228FD8D6100C90400 /* WorkSpaceDetailView.swift */,
 				2D66DCC428FD8D6D00C90400 /* WorkSpaceCreateView.swift */,
+				2D9CE86529003AA600C60F4C /* WorkSpaceCreateScheduleListView.swift */,
 			);
 			path = WorkSpace;
 			sourceTree = "<group>";
@@ -327,6 +330,7 @@
 				2D66DCC128FD8D5100C90400 /* WorkSpaceListView.swift in Sources */,
 				C64D97C728FE92C7004F80E7 /* DayEntity.swift in Sources */,
 				2D66DCD028FD8E1000C90400 /* ScheduleCreateViewModel.swift in Sources */,
+				2D9CE86629003AA600C60F4C /* WorkSpaceCreateScheduleListView.swift in Sources */,
 				C62C338C28FFCEBD00469273 /* CustomButtonView.swift in Sources */,
 				2D66DCBB28FD8D0E00C90400 /* ScheduleListView.swift in Sources */,
 				2D66DCBF28FD8D3700C90400 /* ScheduleUpdateView.swift in Sources */,

--- a/Rlog.xcodeproj/project.pbxproj
+++ b/Rlog.xcodeproj/project.pbxproj
@@ -33,6 +33,8 @@
 		2D66DCE028FD8ECA00C90400 /* MainTabViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D66DCDF28FD8ECA00C90400 /* MainTabViewModel.swift */; };
 		2D66DCE428FD8F1D00C90400 /* Color+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D66DCE328FD8F1D00C90400 /* Color+.swift */; };
 		2D9CE86629003AA600C60F4C /* WorkSpaceCreateScheduleListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D9CE86529003AA600C60F4C /* WorkSpaceCreateScheduleListView.swift */; };
+		2DF4EC712906344B009B48B4 /* WorkSpaceCreateCreatingScheduleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DF4EC702906344B009B48B4 /* WorkSpaceCreateCreatingScheduleView.swift */; };
+		2DF4EC7329063469009B48B4 /* WorkSpaceCreateCreatingScheduleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DF4EC7229063469009B48B4 /* WorkSpaceCreateCreatingScheduleViewModel.swift */; };
 		C62C338C28FFCEBD00469273 /* CustomButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C62C338B28FFCEBD00469273 /* CustomButtonView.swift */; };
 		C64D97BA28FE918F004F80E7 /* Text+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C64D97B928FE918F004F80E7 /* Text+.swift */; };
 		C64D97BC28FE9197004F80E7 /* TextField+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C64D97BB28FE9197004F80E7 /* TextField+.swift */; };
@@ -72,6 +74,8 @@
 		2D66DCDF28FD8ECA00C90400 /* MainTabViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabViewModel.swift; sourceTree = "<group>"; };
 		2D66DCE328FD8F1D00C90400 /* Color+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+.swift"; sourceTree = "<group>"; };
 		2D9CE86529003AA600C60F4C /* WorkSpaceCreateScheduleListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkSpaceCreateScheduleListView.swift; sourceTree = "<group>"; };
+		2DF4EC702906344B009B48B4 /* WorkSpaceCreateCreatingScheduleView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WorkSpaceCreateCreatingScheduleView.swift; sourceTree = "<group>"; };
+		2DF4EC7229063469009B48B4 /* WorkSpaceCreateCreatingScheduleViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WorkSpaceCreateCreatingScheduleViewModel.swift; sourceTree = "<group>"; };
 		C62C338B28FFCEBD00469273 /* CustomButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CustomButtonView.swift; path = Rlog/View/Components/CustomButtonView.swift; sourceTree = SOURCE_ROOT; };
 		C64D97B928FE918F004F80E7 /* Text+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Text+.swift"; sourceTree = "<group>"; };
 		C64D97BB28FE9197004F80E7 /* TextField+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TextField+.swift"; sourceTree = "<group>"; };
@@ -162,6 +166,7 @@
 				2D66DCC228FD8D6100C90400 /* WorkSpaceDetailView.swift */,
 				2D66DCC428FD8D6D00C90400 /* WorkSpaceCreateView.swift */,
 				2D9CE86529003AA600C60F4C /* WorkSpaceCreateScheduleListView.swift */,
+				2DF4EC702906344B009B48B4 /* WorkSpaceCreateCreatingScheduleView.swift */,
 			);
 			path = WorkSpace;
 			sourceTree = "<group>";
@@ -203,6 +208,7 @@
 				2D66DCD928FD8E8F00C90400 /* WorkSpaceDetailViewModel.swift */,
 				2D66DCDB28FD8E9D00C90400 /* WorkSpaceCreateViewModel.swift */,
 				2D5BA7C72900EE34003A6BC7 /* WorkSpaceCreateScheduleListViewModel.swift */,
+				2DF4EC7229063469009B48B4 /* WorkSpaceCreateCreatingScheduleViewModel.swift */,
 			);
 			path = WorkSpace;
 			sourceTree = "<group>";
@@ -339,6 +345,7 @@
 				2D66DCBF28FD8D3700C90400 /* ScheduleUpdateView.swift in Sources */,
 				C64D97C928FE92D8004F80E7 /* Tab.swift in Sources */,
 				2D66DCAB28FD4DF200C90400 /* CoreDataManager.swift in Sources */,
+				2DF4EC7329063469009B48B4 /* WorkSpaceCreateCreatingScheduleViewModel.swift in Sources */,
 				2D66DCD428FD8E4700C90400 /* MonthlyCalculateListViewModel.swift in Sources */,
 				2D5BA7C82900EE34003A6BC7 /* WorkSpaceCreateScheduleListViewModel.swift in Sources */,
 				2D66DCDA28FD8E8F00C90400 /* WorkSpaceDetailViewModel.swift in Sources */,
@@ -356,6 +363,7 @@
 				2D66DCDC28FD8E9D00C90400 /* WorkSpaceCreateViewModel.swift in Sources */,
 				C64D97C028FE91AB004F80E7 /* DateFormatter+.swift in Sources */,
 				2D66DCA228FD4DF000C90400 /* RlogApp.swift in Sources */,
+				2DF4EC712906344B009B48B4 /* WorkSpaceCreateCreatingScheduleView.swift in Sources */,
 				C64D97BC28FE9197004F80E7 /* TextField+.swift in Sources */,
 				2D66DCBD28FD8D2500C90400 /* ScheduleCreateView.swift in Sources */,
 				2D66DCE028FD8ECA00C90400 /* MainTabViewModel.swift in Sources */,

--- a/Rlog.xcodeproj/project.pbxproj
+++ b/Rlog.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2D5BA7C82900EE34003A6BC7 /* WorkSpaceCreateScheduleListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D5BA7C72900EE34003A6BC7 /* WorkSpaceCreateScheduleListViewModel.swift */; };
 		2D66DCA228FD4DF000C90400 /* RlogApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D66DCA128FD4DF000C90400 /* RlogApp.swift */; };
 		2D66DCA628FD4DF200C90400 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2D66DCA528FD4DF200C90400 /* Assets.xcassets */; };
 		2D66DCA928FD4DF200C90400 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2D66DCA828FD4DF200C90400 /* Preview Assets.xcassets */; };
@@ -44,6 +45,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		2D5BA7C72900EE34003A6BC7 /* WorkSpaceCreateScheduleListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkSpaceCreateScheduleListViewModel.swift; sourceTree = "<group>"; };
 		2D66DC9E28FD4DF000C90400 /* Rlog.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Rlog.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2D66DCA128FD4DF000C90400 /* RlogApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RlogApp.swift; sourceTree = "<group>"; };
 		2D66DCA528FD4DF200C90400 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -200,6 +202,7 @@
 				2D66DCD728FD8E7100C90400 /* WorkSpaceListViewModel.swift */,
 				2D66DCD928FD8E8F00C90400 /* WorkSpaceDetailViewModel.swift */,
 				2D66DCDB28FD8E9D00C90400 /* WorkSpaceCreateViewModel.swift */,
+				2D5BA7C72900EE34003A6BC7 /* WorkSpaceCreateScheduleListViewModel.swift */,
 			);
 			path = WorkSpace;
 			sourceTree = "<group>";
@@ -337,6 +340,7 @@
 				C64D97C928FE92D8004F80E7 /* Tab.swift in Sources */,
 				2D66DCAB28FD4DF200C90400 /* CoreDataManager.swift in Sources */,
 				2D66DCD428FD8E4700C90400 /* MonthlyCalculateListViewModel.swift in Sources */,
+				2D5BA7C82900EE34003A6BC7 /* WorkSpaceCreateScheduleListViewModel.swift in Sources */,
 				2D66DCDA28FD8E8F00C90400 /* WorkSpaceDetailViewModel.swift in Sources */,
 				2D66DCC328FD8D6100C90400 /* WorkSpaceDetailView.swift in Sources */,
 				2D66DCAE28FD4DF200C90400 /* DataModel.xcdatamodeld in Sources */,

--- a/Rlog/View/WorkSpace/WorkSpaceCreateCreatingScheduleView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceCreateCreatingScheduleView.swift
@@ -8,9 +8,11 @@
 import SwiftUI
 
 struct WorkSpaceCreateCreatingScheduleView: View {
-    @ObservedObject var viewModel = WorkSpaceCreateCreatingScheduleViewModel()
+    @ObservedObject var viewModel:  WorkSpaceCreateCreatingScheduleViewModel
     @Binding var isShowingModal: Bool
     @Binding var scheduleList: [Schedule]
+    
+    
     
     var body: some View {
         NavigationView {
@@ -48,6 +50,7 @@ private extension WorkSpaceCreateCreatingScheduleView {
     }
     var toolbarConfirmButton: some View {
         Button{
+            // TODO: 넣기 전 데이터를 가공하는게 필요함
             scheduleList.append(Schedule(workDays: viewModel.getDayList() ,startHour: viewModel.startHour, startMinute: viewModel.endMinute, endHour: viewModel.endHour, endMinute: viewModel.endMinute))
             self.isShowingModal = false
         } label: {
@@ -93,6 +96,7 @@ private extension WorkSpaceCreateCreatingScheduleView {
                 Text(":")
                 TextField("00", text: $viewModel.endMinute)
             }
+            .foregroundColor(.fontBlack)
         }
     }
 }

--- a/Rlog/View/WorkSpace/WorkSpaceCreateCreatingScheduleView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceCreateCreatingScheduleView.swift
@@ -1,0 +1,75 @@
+//
+//  WorkSpaceCreateCreatingScheduleView.swift
+//  Rlog
+//
+//  Created by 송시원 on 2022/10/24.
+//
+
+import SwiftUI
+
+struct WorkSpaceCreateCreatingScheduleView: View {
+    @ObservedObject var viewModel = WorkSpaceCreateCreatingScheduleViewModel()
+    
+    var body: some View {
+        NavigationView {
+            VStack(alignment: .leading, spacing: 40) {
+                guidingText
+                workDayPicker
+                workTimePicker
+                Spacer()
+            }
+            .navigationBarTitle(Text("근무 일정 추가하기"), displayMode: .inline)
+            .navigationBarItems(leading:
+                                    Button{
+                self.isShowingModal = false
+            } label: {
+                Text("취소").foregroundColor(.fontLightGray)}
+            )
+            .padding(.horizontal)
+        }
+    }
+}
+
+private extension WorkSpaceCreateCreatingScheduleView {
+    var guidingText: some View {
+        Text("근무 요일과 시간을 입력해주세요.")
+            .padding(.top, 40)
+            .foregroundColor(.fontBlack)
+    }
+    var workDayPicker: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            Text("근무 요일")
+                .font(.caption)
+                .foregroundColor(.fontLightGray)
+            HStack(spacing: 8) {
+                // 더 깔끔한 방식으로 하는 방법은 없을까?
+                ForEach(0 ..< viewModel.sevenDays.count, id: \.self) { index in
+                    Button {
+                        viewModel.didTapDayPicker(index: index)
+                    } label: {
+                        DayButtonSubView(day: viewModel.sevenDays[index].dayName, isSelected: viewModel.sevenDays[index].isSelected)
+                    }
+                }
+            }
+        }
+    }
+    
+    var workTimePicker: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            Text("근무 시간")
+                .font(.caption)
+                .foregroundColor(.fontLightGray)
+            HStack(spacing: 0) {
+                // TODO: 컨포넌트 적용
+                TextField("00", text: $viewModel.startHour)
+                Text(":")
+                TextField("00", text: $viewModel.startMinute)
+                Text("-")
+                    .padding(.horizontal, 10)
+                TextField("00", text: $viewModel.endHour)
+                Text(":")
+                TextField("00", text: $viewModel.endMinute)
+            }
+        }
+    }
+}

--- a/Rlog/View/WorkSpace/WorkSpaceCreateCreatingScheduleView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceCreateCreatingScheduleView.swift
@@ -23,21 +23,11 @@ struct WorkSpaceCreateCreatingScheduleView: View {
             .navigationBarTitle(Text("근무 일정 추가하기"), displayMode: .inline)
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
-                    Button{
-                        self.isShowingModal = false
-                    } label: {
-                        Text("취소")
-                        .foregroundColor(.fontLightGray)
-                    }
+                    toolbarCancelButton
                 }
                 ToolbarItem(placement: .navigationBarTrailing) {
                     if viewModel.isShowingConfirmButton {
-                        Button{
-                            scheduleList.append(Schedule(workDays: viewModel.getDayList() ,startHour: viewModel.startHour, startMinute: viewModel.endMinute, endHour: viewModel.endHour, endMinute: viewModel.endMinute))
-                            self.isShowingModal = false
-                        } label: {
-                            Text("완료")
-                        }
+                        toolbarConfirmButton
                     }
                 }
             }
@@ -47,6 +37,23 @@ struct WorkSpaceCreateCreatingScheduleView: View {
 }
 
 private extension WorkSpaceCreateCreatingScheduleView {
+    // 툴바 버튼들
+    var toolbarCancelButton: some View {
+        Button{
+            self.isShowingModal = false
+        } label: {
+            Text("취소")
+            .foregroundColor(.fontLightGray)
+        }
+    }
+    var toolbarConfirmButton: some View {
+        Button{
+            scheduleList.append(Schedule(workDays: viewModel.getDayList() ,startHour: viewModel.startHour, startMinute: viewModel.endMinute, endHour: viewModel.endHour, endMinute: viewModel.endMinute))
+            self.isShowingModal = false
+        } label: {
+            Text("완료")
+        }
+    }
     var guidingText: some View {
         Text("근무 요일과 시간을 입력해주세요.")
             .padding(.top, 40)

--- a/Rlog/View/WorkSpace/WorkSpaceCreateCreatingScheduleView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceCreateCreatingScheduleView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct WorkSpaceCreateCreatingScheduleView: View {
     @ObservedObject var viewModel = WorkSpaceCreateCreatingScheduleViewModel()
     @Binding var isShowingModal: Bool
+    @Binding var scheduleList: [Schedule]
     
     var body: some View {
         NavigationView {
@@ -20,12 +21,26 @@ struct WorkSpaceCreateCreatingScheduleView: View {
                 Spacer()
             }
             .navigationBarTitle(Text("근무 일정 추가하기"), displayMode: .inline)
-            .navigationBarItems(leading:
-                                    Button{
-                self.isShowingModal = false
-            } label: {
-                Text("취소").foregroundColor(.fontLightGray)}
-            )
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button{
+                        self.isShowingModal = false
+                    } label: {
+                        Text("취소")
+                        .foregroundColor(.fontLightGray)
+                    }
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    if viewModel.isShowingConfirmButton {
+                        Button{
+                            scheduleList.append(Schedule(workDays: viewModel.getDayList() ,startHour: viewModel.startHour, startMinute: viewModel.endMinute, endHour: viewModel.endHour, endMinute: viewModel.endMinute))
+                            self.isShowingModal = false
+                        } label: {
+                            Text("완료")
+                        }
+                    }
+                }
+            }
             .padding(.horizontal)
         }
     }

--- a/Rlog/View/WorkSpace/WorkSpaceCreateCreatingScheduleView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceCreateCreatingScheduleView.swift
@@ -92,6 +92,11 @@ private extension WorkSpaceCreateCreatingScheduleView {
                     .keyboardType(.decimalPad)
                 Text("-")
                     .padding(.horizontal, 10)
+                if viewModel.isShowingOverSingleDay {
+                    Text("익일")
+                        .font(.caption)
+                        .foregroundColor(.fontDarkGray)
+                }
                 TextField("00", text: $viewModel.endHour)
                     .keyboardType(.decimalPad)
                 Text(":")
@@ -99,6 +104,9 @@ private extension WorkSpaceCreateCreatingScheduleView {
                     .keyboardType(.decimalPad)
             }
             .foregroundColor(.fontBlack)
+            Text(viewModel.errorMessage)
+                .font(.caption)
+                .foregroundColor(.fontLightGray)
         }
     }
 }

--- a/Rlog/View/WorkSpace/WorkSpaceCreateCreatingScheduleView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceCreateCreatingScheduleView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct WorkSpaceCreateCreatingScheduleView: View {
     @ObservedObject var viewModel = WorkSpaceCreateCreatingScheduleViewModel()
+    @Binding var isShowingModal: Bool
     
     var body: some View {
         NavigationView {

--- a/Rlog/View/WorkSpace/WorkSpaceCreateCreatingScheduleView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceCreateCreatingScheduleView.swift
@@ -76,6 +76,7 @@ private extension WorkSpaceCreateCreatingScheduleView {
                 }
             }
         }
+        
     }
     
     var workTimePicker: some View {
@@ -107,6 +108,26 @@ private extension WorkSpaceCreateCreatingScheduleView {
             Text(viewModel.errorMessage)
                 .font(.caption)
                 .foregroundColor(.red)
+        }
+    }
+    
+    private struct DayButtonSubView: View {
+        
+        let day: String
+        let isSelected: Bool
+        
+        var body: some View {
+            ZStack {
+                RoundedRectangle(cornerRadius: 10)
+                    .foregroundColor(.accentColor)
+                    .opacity(isSelected ? 1 : 0)
+                RoundedRectangle(cornerRadius: 10)
+                    .strokeBorder(Color(red: 0.769, green: 0.769, blue: 0.769), lineWidth: 1)
+                    .opacity(isSelected ? 0 : 1)
+                Text(day)
+                    .foregroundColor(isSelected ? .white : .fontBlack)
+            }
+            .frame(height: 60)
         }
     }
 }

--- a/Rlog/View/WorkSpace/WorkSpaceCreateCreatingScheduleView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceCreateCreatingScheduleView.swift
@@ -12,8 +12,6 @@ struct WorkSpaceCreateCreatingScheduleView: View {
     @Binding var isShowingModal: Bool
     @Binding var scheduleList: [Schedule]
     
-    
-    
     var body: some View {
         NavigationView {
             VStack(alignment: .leading, spacing: 40) {

--- a/Rlog/View/WorkSpace/WorkSpaceCreateCreatingScheduleView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceCreateCreatingScheduleView.swift
@@ -86,13 +86,17 @@ private extension WorkSpaceCreateCreatingScheduleView {
             HStack(spacing: 0) {
                 // TODO: 컨포넌트 적용
                 TextField("00", text: $viewModel.startHour)
+                    .keyboardType(.decimalPad)
                 Text(":")
                 TextField("00", text: $viewModel.startMinute)
+                    .keyboardType(.decimalPad)
                 Text("-")
                     .padding(.horizontal, 10)
                 TextField("00", text: $viewModel.endHour)
+                    .keyboardType(.decimalPad)
                 Text(":")
                 TextField("00", text: $viewModel.endMinute)
+                    .keyboardType(.decimalPad)
             }
             .foregroundColor(.fontBlack)
         }

--- a/Rlog/View/WorkSpace/WorkSpaceCreateCreatingScheduleView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceCreateCreatingScheduleView.swift
@@ -8,9 +8,11 @@
 import SwiftUI
 
 struct WorkSpaceCreateCreatingScheduleView: View {
-    @ObservedObject var viewModel:  WorkSpaceCreateCreatingScheduleViewModel
-    @Binding var isShowingModal: Bool
-    @Binding var scheduleList: [Schedule]
+    @ObservedObject private var viewModel:  WorkSpaceCreateCreatingScheduleViewModel
+    
+    init(isShowingModal: Binding<Bool>, scheduleList: Binding<[Schedule]>) {
+        self.viewModel = WorkSpaceCreateCreatingScheduleViewModel(isShowingModal: isShowingModal, scheduleList: scheduleList)
+    }
     
     var body: some View {
         NavigationView {
@@ -40,7 +42,7 @@ private extension WorkSpaceCreateCreatingScheduleView {
     // 툴바 버튼들
     var toolbarCancelButton: some View {
         Button{
-            self.isShowingModal = false
+            viewModel.isShowingModal = false
         } label: {
             Text("취소")
             .foregroundColor(.fontLightGray)
@@ -48,9 +50,7 @@ private extension WorkSpaceCreateCreatingScheduleView {
     }
     var toolbarConfirmButton: some View {
         Button{
-            // TODO: 넣기 전 데이터를 가공하는게 필요함
-            scheduleList.append(Schedule(workDays: viewModel.getDayList() ,startHour: viewModel.startHour, startMinute: viewModel.endMinute, endHour: viewModel.endHour, endMinute: viewModel.endMinute))
-            self.isShowingModal = false
+            viewModel.didTapConfirmButton()
         } label: {
             Text("완료")
         }

--- a/Rlog/View/WorkSpace/WorkSpaceCreateCreatingScheduleView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceCreateCreatingScheduleView.swift
@@ -106,7 +106,7 @@ private extension WorkSpaceCreateCreatingScheduleView {
             .foregroundColor(.fontBlack)
             Text(viewModel.errorMessage)
                 .font(.caption)
-                .foregroundColor(.fontLightGray)
+                .foregroundColor(.red)
         }
     }
 }

--- a/Rlog/View/WorkSpace/WorkSpaceCreateScheduleListView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceCreateScheduleListView.swift
@@ -17,6 +17,7 @@ struct WorkSpaceCreateScheduleListView: View {
             Text("sample")
             labelText
         }
+        .padding()
     }
 }
 

--- a/Rlog/View/WorkSpace/WorkSpaceCreateScheduleListView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceCreateScheduleListView.swift
@@ -13,8 +13,7 @@ struct WorkSpaceCreateScheduleListView: View {
     
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
-            //타이틀 섭뷰 넣기 "근무 일정을 입력해주세요." Or "근무 유형을 추가해주세요!"
-            Text("sample")
+            guidingText
             labelText
             VStack(spacing: 16) {
                 //리스트 불러와서 반복문으로 돌리기
@@ -23,10 +22,7 @@ struct WorkSpaceCreateScheduleListView: View {
                     RoundedRectangle(cornerRadius: 10)
                         .frame(maxHeight: 56)
                 }
-                //컨포넌트로 대체하기
-                Button {} label: {
-                    Text("+ 근무 일정 추가하기")
-                }
+                addScheduleButton
             }
             Spacer()
             
@@ -36,10 +32,28 @@ struct WorkSpaceCreateScheduleListView: View {
 }
 
 private extension WorkSpaceCreateScheduleListView {
+    var guidingText: some View {
+        Text("근무 요일과 시간을 입력해주세요.")
+            .padding(.vertical, 20)
+    }
     var labelText: some View {
         Text("근무 유형")
             .font(.caption)
             .foregroundColor(.fontLightGray)
+    }
+    var addScheduleButton: some View {
+        //컨포넌트로 대체하기
+        Button {
+        } label: {
+            ZStack {
+                RoundedRectangle(cornerRadius: 10)
+                    .frame(height: 58)
+                    .foregroundColor(.fontLightGray)
+                Text("+ 근무 일정 추가하기")
+                    .foregroundColor(.white)
+            }
+            }
+        }
     }
 }
 

--- a/Rlog/View/WorkSpace/WorkSpaceCreateScheduleListView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceCreateScheduleListView.swift
@@ -32,7 +32,7 @@ private extension WorkSpaceCreateScheduleListView {
     @ViewBuilder
     func createScheduleListCell(for item: Schedule) -> some View {
         HStack(spacing: 0) {
-            ForEach(item.workDays,id: \.self) { day in
+            ForEach(item.repeatedSchedule,id: \.self) { day in
                 Text("\(day) ")
             }
             Spacer()

--- a/Rlog/View/WorkSpace/WorkSpaceCreateScheduleListView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceCreateScheduleListView.swift
@@ -16,6 +16,20 @@ struct WorkSpaceCreateScheduleListView: View {
             //타이틀 섭뷰 넣기 "근무 일정을 입력해주세요." Or "근무 유형을 추가해주세요!"
             Text("sample")
             labelText
+            VStack(spacing: 16) {
+                //리스트 불러와서 반복문으로 돌리기
+                ForEach(1 ..< 3, id: \.self) { s in
+                    //컨포넌트로 대체하기
+                    RoundedRectangle(cornerRadius: 10)
+                        .frame(maxHeight: 56)
+                }
+                //컨포넌트로 대체하기
+                Button {} label: {
+                    Text("+ 근무 일정 추가하기")
+                }
+            }
+            Spacer()
+            
         }
         .padding()
     }

--- a/Rlog/View/WorkSpace/WorkSpaceCreateScheduleListView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceCreateScheduleListView.swift
@@ -24,7 +24,7 @@ struct WorkSpaceCreateScheduleListView: View {
             Spacer()
             
         }
-        .padding()
+        .padding(.horizontal)
     }
 }
 

--- a/Rlog/View/WorkSpace/WorkSpaceCreateScheduleListView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceCreateScheduleListView.swift
@@ -15,12 +15,9 @@ struct WorkSpaceCreateScheduleListView: View {
             guidingText
             labelText
             VStack(spacing: 16) {
-                //리스트 불러와서 반복문으로 돌리기
                 ForEach(viewModel.scheduleList, id: \.self) { item in
                     createScheduleListCell(for: item)
-                    //컨포넌트로 대체하기
-                    RoundedRectangle(cornerRadius: 10)
-                        .frame(maxHeight: 56)
+                    // TODO: 컨포넌트로 대체하기
                 }
                 addScheduleButton
             }
@@ -41,6 +38,9 @@ private extension WorkSpaceCreateScheduleListView {
             Spacer()
             Text("\(item.startHour):\(item.startMinute) - \(item.endHour):\(item.endMinute)")
         }
+        .padding()
+        .background(Color(red: 0.962, green: 0.962, blue: 0.962))
+        .clipShape(RoundedRectangle(cornerRadius: 10))
     }
     var guidingText: some View {
         Text("근무 일정을 입력해주세요.")

--- a/Rlog/View/WorkSpace/WorkSpaceCreateScheduleListView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceCreateScheduleListView.swift
@@ -29,6 +29,9 @@ struct WorkSpaceCreateScheduleListView: View {
             ToolbarItem(placement: .navigationBarTrailing) {
                 if viewModel.isShowingConfirmButton {
                     toolbarConfirmButton
+                } else {
+                    // TODO: 뷰 연결하면서 navigation 될 때에 삭제해야함.
+                    Text("")
                 }
             }
         }

--- a/Rlog/View/WorkSpace/WorkSpaceCreateScheduleListView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceCreateScheduleListView.swift
@@ -25,6 +25,13 @@ struct WorkSpaceCreateScheduleListView: View {
             
         }
         .padding(.horizontal)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                if viewModel.isShowingConfirmButton {
+                    toolbarConfirmButton
+                }
+            }
+        }
     }
 }
 
@@ -41,6 +48,11 @@ private extension WorkSpaceCreateScheduleListView {
         .padding()
         .background(Color(red: 0.962, green: 0.962, blue: 0.962))
         .clipShape(RoundedRectangle(cornerRadius: 10))
+    }
+    var toolbarConfirmButton: some View {
+            NavigationLink(destination: Rectangle()) {
+                Text("완료")
+            }
     }
     var guidingText: some View {
         Text("근무 일정을 입력해주세요.")

--- a/Rlog/View/WorkSpace/WorkSpaceCreateScheduleListView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceCreateScheduleListView.swift
@@ -31,7 +31,7 @@ struct WorkSpaceCreateScheduleListView: View {
 private extension WorkSpaceCreateScheduleListView {
     @ViewBuilder
     func createScheduleListCell(for item: Schedule) -> some View {
-        HStack {
+        HStack(spacing: 0) {
             ForEach(item.workDays,id: \.self) { day in
                 Text("\(day) ")
             }

--- a/Rlog/View/WorkSpace/WorkSpaceCreateScheduleListView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceCreateScheduleListView.swift
@@ -16,8 +16,8 @@ struct WorkSpaceCreateScheduleListView: View {
             labelText
             VStack(spacing: 16) {
                 //리스트 불러와서 반복문으로 돌리기
-                ForEach(viewModel.scheduleList, id: \.self) { s in
-                    scheduleItem(s)
+                ForEach(viewModel.scheduleList, id: \.self) { item in
+                    createScheduleListCell(for: item)
                     //컨포넌트로 대체하기
                     RoundedRectangle(cornerRadius: 10)
                         .frame(maxHeight: 56)
@@ -32,8 +32,19 @@ struct WorkSpaceCreateScheduleListView: View {
 }
 
 private extension WorkSpaceCreateScheduleListView {
+    @ViewBuilder
+    func createScheduleListCell(for item: Schedule) -> some View {
+        HStack {
+            ForEach(item.workDays,id: \.self) { day in
+                Text("\(day) ")
+            }
+            Spacer()
+            Text("\(item.startHour):\(item.startMinute) - \(item.endHour):\(item.endMinute)")
+        }
+            
+    }
     var guidingText: some View {
-        Text("근무 요일과 시간을 입력해주세요.")
+        Text("근무 일정을 입력해주세요.")
             .padding(.vertical, 20)
     }
     var labelText: some View {

--- a/Rlog/View/WorkSpace/WorkSpaceCreateScheduleListView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceCreateScheduleListView.swift
@@ -65,7 +65,7 @@ private extension WorkSpaceCreateScheduleListView {
                     .foregroundColor(.white)
             }
             .sheet(isPresented: $viewModel.isShowingModal) {
-                Rectangle()
+                WorkSpaceCreateCreatingScheduleView(isShowingModal: $viewModel.isShowingModal)
             }
         }
     }

--- a/Rlog/View/WorkSpace/WorkSpaceCreateScheduleListView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceCreateScheduleListView.swift
@@ -41,7 +41,6 @@ private extension WorkSpaceCreateScheduleListView {
             Spacer()
             Text("\(item.startHour):\(item.startMinute) - \(item.endHour):\(item.endMinute)")
         }
-            
     }
     var guidingText: some View {
         Text("근무 일정을 입력해주세요.")
@@ -53,7 +52,7 @@ private extension WorkSpaceCreateScheduleListView {
             .foregroundColor(.fontLightGray)
     }
     var addScheduleButton: some View {
-        //컨포넌트로 대체하기
+        // TODO: 컨포넌트로 대체하기
         Button {
             viewModel.didTapAddScheduleButton()
         } label: {
@@ -65,7 +64,7 @@ private extension WorkSpaceCreateScheduleListView {
                     .foregroundColor(.white)
             }
             .sheet(isPresented: $viewModel.isShowingModal) {
-                WorkSpaceCreateCreatingScheduleView(isShowingModal: $viewModel.isShowingModal)
+                WorkSpaceCreateCreatingScheduleView(isShowingModal: $viewModel.isShowingModal, scheduleList: $viewModel.scheduleList)
             }
         }
     }

--- a/Rlog/View/WorkSpace/WorkSpaceCreateScheduleListView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceCreateScheduleListView.swift
@@ -53,6 +53,8 @@ private extension WorkSpaceCreateScheduleListView {
                 Text("+ 근무 일정 추가하기")
                     .foregroundColor(.white)
             }
+            .sheet(isPresented: $viewModel.isShowingModal) {
+                Rectangle()
             }
         }
     }

--- a/Rlog/View/WorkSpace/WorkSpaceCreateScheduleListView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceCreateScheduleListView.swift
@@ -13,7 +13,16 @@ struct WorkSpaceCreateScheduleListView: View {
         VStack(alignment: .leading, spacing: 20) {
             //타이틀 섭뷰 넣기 "근무 일정을 입력해주세요." Or "근무 유형을 추가해주세요!"
             Text("sample")
+            labelText
         }
+    }
+}
+
+private extension WorkSpaceCreateScheduleListView {
+    var labelText: some View {
+        Text("근무 유형")
+            .font(.caption)
+            .foregroundColor(.fontLightGray)
     }
 }
 

--- a/Rlog/View/WorkSpace/WorkSpaceCreateScheduleListView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceCreateScheduleListView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 struct WorkSpaceCreateScheduleListView: View {
     
+    @State var isNavigationActivated: Bool = false
+    
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
             //타이틀 섭뷰 넣기 "근무 일정을 입력해주세요." Or "근무 유형을 추가해주세요!"

--- a/Rlog/View/WorkSpace/WorkSpaceCreateScheduleListView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceCreateScheduleListView.swift
@@ -8,8 +8,7 @@
 import SwiftUI
 
 struct WorkSpaceCreateScheduleListView: View {
-    
-    @State var isNavigationActivated: Bool = false
+    @ObservedObject var viewModel = WorkSpaceCreateScheduleListViewModel()
     
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
@@ -17,7 +16,8 @@ struct WorkSpaceCreateScheduleListView: View {
             labelText
             VStack(spacing: 16) {
                 //리스트 불러와서 반복문으로 돌리기
-                ForEach(1 ..< 3, id: \.self) { s in
+                ForEach(viewModel.scheduleList, id: \.self) { s in
+                    scheduleItem(s)
                     //컨포넌트로 대체하기
                     RoundedRectangle(cornerRadius: 10)
                         .frame(maxHeight: 56)
@@ -44,6 +44,7 @@ private extension WorkSpaceCreateScheduleListView {
     var addScheduleButton: some View {
         //컨포넌트로 대체하기
         Button {
+            viewModel.didTapAddScheduleButton()
         } label: {
             ZStack {
                 RoundedRectangle(cornerRadius: 10)

--- a/Rlog/View/WorkSpace/WorkSpaceCreateScheduleListView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceCreateScheduleListView.swift
@@ -1,0 +1,24 @@
+//
+//  WorkSpaceCreateScheduleListView.swift
+//  Rlog
+//
+//  Created by 송시원 on 2022/10/19.
+//
+
+import SwiftUI
+
+struct WorkSpaceCreateScheduleListView: View {
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            //타이틀 섭뷰 넣기 "근무 일정을 입력해주세요." Or "근무 유형을 추가해주세요!"
+            Text("sample")
+        }
+    }
+}
+
+struct WorkSpaceCreateScheduleListView_Previews: PreviewProvider {
+    static var previews: some View {
+        WorkSpaceCreateScheduleListView()
+    }
+}

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceCreateCreatingScheduleViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceCreateCreatingScheduleViewModel.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 final class WorkSpaceCreateCreatingScheduleViewModel: ObservableObject {
+    @Published var isShowingConfirmButton = false
+    
     // 어떻게 더 깔끔하게 짤 수 있을까요? enum을 사용하면 깔끔해질까요?
     @Published var sevenDays: [selectedDayModel] = [selectedDayModel(dayName: "월", isSelected: false), selectedDayModel(dayName: "화", isSelected: false), selectedDayModel(dayName: "수", isSelected: false), selectedDayModel(dayName: "목", isSelected: false), selectedDayModel(dayName: "금", isSelected: false), selectedDayModel(dayName: "토", isSelected: false), selectedDayModel(dayName: "일", isSelected: false)]
 //    @Published var pickedDays: [String] = []

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceCreateCreatingScheduleViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceCreateCreatingScheduleViewModel.swift
@@ -12,6 +12,8 @@ final class WorkSpaceCreateCreatingScheduleViewModel: ObservableObject {
     @Binding var scheduleList: [Schedule]
     
     @Published var isShowingConfirmButton = false
+    @Published var isShowingOverSingleDay = false
+    @Published var errorMessage = "ananan"
     
     // 어떻게 더 깔끔하게 짤 수 있을까요? enum을 사용하면 깔끔해질까요?
     @Published var sevenDays: [selectedDayModel] = [selectedDayModel(dayName: "월", isSelected: false), selectedDayModel(dayName: "화", isSelected: false), selectedDayModel(dayName: "수", isSelected: false), selectedDayModel(dayName: "목", isSelected: false), selectedDayModel(dayName: "금", isSelected: false), selectedDayModel(dayName: "토", isSelected: false), selectedDayModel(dayName: "일", isSelected: false)]
@@ -20,6 +22,7 @@ final class WorkSpaceCreateCreatingScheduleViewModel: ObservableObject {
         didSet {
             // TODO: 입력값이 24시간을 넘어가면 경고처리 하기
             checkAllInputFilled()
+            checkIsOverSingleDay()
         }
     }
     @Published var startMinute = ""
@@ -27,6 +30,7 @@ final class WorkSpaceCreateCreatingScheduleViewModel: ObservableObject {
         didSet {
             // TODO: 입력값이 24시간을 넘어가면 경고처리 하기
             checkAllInputFilled()
+            checkIsOverSingleDay()
         }
     }
     @Published var endMinute = ""
@@ -44,11 +48,19 @@ final class WorkSpaceCreateCreatingScheduleViewModel: ObservableObject {
         appendScheduleToList()
         dismissModal()
     }
-    
 }
 
 extension WorkSpaceCreateCreatingScheduleViewModel {
-    
+    func checkIsOverSingleDay() {
+        if !startHour.isEmpty && !endHour.isEmpty  {
+            if Int(startHour) ?? 0 >= Int(endHour) ?? 0 {
+                isShowingOverSingleDay = true
+                return
+            }
+        }
+        isShowingOverSingleDay = false
+
+    }
     func appendScheduleToList() {
         scheduleList.append(Schedule(repeatedSchedule: getDayList() ,startHour: startHour, startMinute: startMinute, endHour: endHour, endMinute: endMinute))
     }

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceCreateCreatingScheduleViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceCreateCreatingScheduleViewModel.swift
@@ -10,18 +10,48 @@ import SwiftUI
 final class WorkSpaceCreateCreatingScheduleViewModel: ObservableObject {
     // 어떻게 더 깔끔하게 짤 수 있을까요? enum을 사용하면 깔끔해질까요?
     @Published var sevenDays: [selectedDayModel] = [selectedDayModel(dayName: "월", isSelected: false), selectedDayModel(dayName: "화", isSelected: false), selectedDayModel(dayName: "수", isSelected: false), selectedDayModel(dayName: "목", isSelected: false), selectedDayModel(dayName: "금", isSelected: false), selectedDayModel(dayName: "토", isSelected: false), selectedDayModel(dayName: "일", isSelected: false)]
-    @Published var startHour = ""
+//    @Published var pickedDays: [String] = []
+    @Published var startHour = "" {
+        didSet {
+            // TODO: 입력값이 24시간을 넘어가면 경고처리 하기
+            checkAllInputFilled()
+        }
+    }
     @Published var startMinute = ""
-    @Published var endHour = ""
+    @Published var endHour = "" {
+        didSet {
+            // TODO: 입력값이 24시간을 넘어가면 경고처리 하기
+            checkAllInputFilled()
+        }
+    }
     @Published var endMinute = ""
     
-
-    // let dayList = ["월","화","수","목","금","토","일"]
     func didTapDayPicker(index: Int) {
         sevenDays[index].isSelected.toggle()
-    } 
+        checkAllInputFilled()
+    }
 
 }
+
+extension WorkSpaceCreateCreatingScheduleViewModel {
+    func getDayList() -> [String] {
+        var dayList: [String] = []
+        for day in sevenDays {
+            if day.isSelected {
+                dayList.append(day.dayName)
+            }
+        }
+        return dayList
+    }
+    func checkAllInputFilled() {
+        if !startHour.isEmpty && !endHour.isEmpty && startHour != endHour && !getDayList().isEmpty {
+            isShowingConfirmButton = true
+            return
+        }
+        isShowingConfirmButton = false
+    }
+}
+
 struct selectedDayModel: Hashable {
     let dayName: String
     var isSelected: Bool

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceCreateCreatingScheduleViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceCreateCreatingScheduleViewModel.swift
@@ -62,6 +62,12 @@ extension WorkSpaceCreateCreatingScheduleViewModel {
 
     }
     func appendScheduleToList() {
+        if startMinute.isEmpty {
+            startMinute = "00"
+        }
+        if endMinute.isEmpty {
+            endMinute = "00"
+        }
         scheduleList.append(Schedule(repeatedSchedule: getDayList() ,startHour: startHour, startMinute: startMinute, endHour: endHour, endMinute: endMinute))
     }
     func dismissModal() {

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceCreateCreatingScheduleViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceCreateCreatingScheduleViewModel.swift
@@ -13,27 +13,56 @@ final class WorkSpaceCreateCreatingScheduleViewModel: ObservableObject {
     
     @Published var isShowingConfirmButton = false
     @Published var isShowingOverSingleDay = false
-    @Published var errorMessage = "ananan"
+    @Published var errorMessage = ""
     
     // 어떻게 더 깔끔하게 짤 수 있을까요? enum을 사용하면 깔끔해질까요?
     @Published var sevenDays: [selectedDayModel] = [selectedDayModel(dayName: "월", isSelected: false), selectedDayModel(dayName: "화", isSelected: false), selectedDayModel(dayName: "수", isSelected: false), selectedDayModel(dayName: "목", isSelected: false), selectedDayModel(dayName: "금", isSelected: false), selectedDayModel(dayName: "토", isSelected: false), selectedDayModel(dayName: "일", isSelected: false)]
     
     @Published var startHour = "" {
         didSet {
-            // TODO: 입력값이 24시간을 넘어가면 경고처리 하기
+            
+            if Int(startHour) ?? 0 > 24 {
+                startHour = oldValue
+                errorMessage = "24시간을 초과한 값을 넣을 수 없습니다."
+            } else {
+                errorMessage = ""
+            }
             checkAllInputFilled()
             checkIsOverSingleDay()
         }
     }
-    @Published var startMinute = ""
+    @Published var startMinute = "" {
+        didSet {
+            if Int(startMinute) ?? 0 > 59 {
+                startMinute = oldValue
+                errorMessage = "59분을 초과한 값을 넣을 수 없습니다."
+            } else {
+                errorMessage = ""
+            }
+        }
+    }
     @Published var endHour = "" {
         didSet {
-            // TODO: 입력값이 24시간을 넘어가면 경고처리 하기
+            if Int(endHour) ?? 0 > 24 {
+                endHour = oldValue
+                errorMessage = "24시간을 초과한 값을 넣을 수 없습니다."
+            } else {
+                errorMessage = ""
+            }
             checkAllInputFilled()
             checkIsOverSingleDay()
         }
     }
-    @Published var endMinute = ""
+    @Published var endMinute = "" {
+        didSet {
+            if Int(endMinute) ?? 0 > 59 {
+                endMinute = oldValue
+                errorMessage = "59분을 초과한 값을 넣을 수 없습니다."
+            } else {
+                errorMessage = ""
+            }
+        }
+    }
     
     init(isShowingModal: Binding<Bool>, scheduleList: Binding<[Schedule]>) {
         self._isShowingModal = isShowingModal

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceCreateCreatingScheduleViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceCreateCreatingScheduleViewModel.swift
@@ -8,11 +8,14 @@
 import SwiftUI
 
 final class WorkSpaceCreateCreatingScheduleViewModel: ObservableObject {
+    @Binding var isShowingModal: Bool
+    @Binding var scheduleList: [Schedule]
+    
     @Published var isShowingConfirmButton = false
     
     // 어떻게 더 깔끔하게 짤 수 있을까요? enum을 사용하면 깔끔해질까요?
     @Published var sevenDays: [selectedDayModel] = [selectedDayModel(dayName: "월", isSelected: false), selectedDayModel(dayName: "화", isSelected: false), selectedDayModel(dayName: "수", isSelected: false), selectedDayModel(dayName: "목", isSelected: false), selectedDayModel(dayName: "금", isSelected: false), selectedDayModel(dayName: "토", isSelected: false), selectedDayModel(dayName: "일", isSelected: false)]
-//    @Published var pickedDays: [String] = []
+    
     @Published var startHour = "" {
         didSet {
             // TODO: 입력값이 24시간을 넘어가면 경고처리 하기
@@ -28,14 +31,30 @@ final class WorkSpaceCreateCreatingScheduleViewModel: ObservableObject {
     }
     @Published var endMinute = ""
     
+    init(isShowingModal: Binding<Bool>, scheduleList: Binding<[Schedule]>) {
+        self._isShowingModal = isShowingModal
+        self._scheduleList = scheduleList
+    }
+    
     func didTapDayPicker(index: Int) {
         sevenDays[index].isSelected.toggle()
         checkAllInputFilled()
     }
-
+    func didTapConfirmButton() {
+        appendScheduleToList()
+        dismissModal()
+    }
+    
 }
 
 extension WorkSpaceCreateCreatingScheduleViewModel {
+    
+    func appendScheduleToList() {
+        scheduleList.append(Schedule(repeatedSchedule: getDayList() ,startHour: startHour, startMinute: startMinute, endHour: endHour, endMinute: endMinute))
+    }
+    func dismissModal() {
+        isShowingModal = false
+    }
     func getDayList() -> [String] {
         var dayList: [String] = []
         for day in sevenDays {

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceCreateCreatingScheduleViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceCreateCreatingScheduleViewModel.swift
@@ -124,23 +124,3 @@ struct selectedDayModel: Hashable {
     let dayName: String
     var isSelected: Bool
 }
-
-struct DayButtonSubView: View {
-    
-    let day: String
-    let isSelected: Bool
-    
-    var body: some View {
-        ZStack {
-            RoundedRectangle(cornerRadius: 10)
-                .foregroundColor(.accentColor)
-                .opacity(isSelected ? 1 : 0)
-            RoundedRectangle(cornerRadius: 10)
-                .strokeBorder(Color(red: 0.769, green: 0.769, blue: 0.769), lineWidth: 1)
-                .opacity(isSelected ? 0 : 1)
-            Text(day)
-                .foregroundColor(isSelected ? .white : .fontBlack)
-        }
-        .frame(height: 60)
-    }
-}

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceCreateCreatingScheduleViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceCreateCreatingScheduleViewModel.swift
@@ -26,3 +26,23 @@ struct selectedDayModel: Hashable {
     let dayName: String
     var isSelected: Bool
 }
+
+struct DayButtonSubView: View {
+    
+    let day: String
+    let isSelected: Bool
+    
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 10)
+                .foregroundColor(.accentColor)
+                .opacity(isSelected ? 1 : 0)
+            RoundedRectangle(cornerRadius: 10)
+                .strokeBorder(Color(red: 0.769, green: 0.769, blue: 0.769), lineWidth: 1)
+                .opacity(isSelected ? 0 : 1)
+            Text(day)
+                .foregroundColor(isSelected ? .white : .fontBlack)
+        }
+        .frame(height: 60)
+    }
+}

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceCreateCreatingScheduleViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceCreateCreatingScheduleViewModel.swift
@@ -1,0 +1,28 @@
+//
+//  WorkSpaceCreateCreatingScheduleViewModel.swift
+//  Rlog
+//
+//  Created by 송시원 on 2022/10/24.
+//
+
+import SwiftUI
+
+final class WorkSpaceCreateCreatingScheduleViewModel: ObservableObject {
+    // 어떻게 더 깔끔하게 짤 수 있을까요? enum을 사용하면 깔끔해질까요?
+    @Published var sevenDays: [selectedDayModel] = [selectedDayModel(dayName: "월", isSelected: false), selectedDayModel(dayName: "화", isSelected: false), selectedDayModel(dayName: "수", isSelected: false), selectedDayModel(dayName: "목", isSelected: false), selectedDayModel(dayName: "금", isSelected: false), selectedDayModel(dayName: "토", isSelected: false), selectedDayModel(dayName: "일", isSelected: false)]
+    @Published var startHour = ""
+    @Published var startMinute = ""
+    @Published var endHour = ""
+    @Published var endMinute = ""
+    
+
+    // let dayList = ["월","화","수","목","금","토","일"]
+    func didTapDayPicker(index: Int) {
+        sevenDays[index].isSelected.toggle()
+    } 
+
+}
+struct selectedDayModel: Hashable {
+    let dayName: String
+    var isSelected: Bool
+}

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceCreateScheduleListViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceCreateScheduleListViewModel.swift
@@ -1,0 +1,14 @@
+//
+//  WorkSpaceCreateScheduleListViewModel.swift
+//  Rlog
+//
+//  Created by 송시원 on 2022/10/20.
+//
+
+import SwiftUI
+
+struct WorkSpaceCreateScheduleListViewModel: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceCreateScheduleListViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceCreateScheduleListViewModel.swift
@@ -12,3 +12,10 @@ struct WorkSpaceCreateScheduleListViewModel: View {
         Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
     }
 }
+struct Schedule: Hashable{
+    var workDays: [String] = []
+    var startHour: String = ""
+    var startMinute: String = ""
+    var endHour: String = ""
+    var endMinute: String = ""
+}

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceCreateScheduleListViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceCreateScheduleListViewModel.swift
@@ -24,7 +24,7 @@ extension WorkSpaceCreateScheduleListViewModel {
 }
 
 struct Schedule: Hashable{
-    var workDays: [String] = []
+    var repeatedSchedule: [String] = []
     var startHour: String = ""
     var startMinute: String = ""
     var endHour: String = ""

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceCreateScheduleListViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceCreateScheduleListViewModel.swift
@@ -10,6 +10,7 @@ import SwiftUI
 final class WorkSpaceCreateScheduleListViewModel: ObservableObject {
     @Published var isNavigationActivated = false
     @Published var scheduleList: [Schedule] = []
+    @Published var isShowingModal = false
     
     func didTapAddScheduleButton() {
         showModal()

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceCreateScheduleListViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceCreateScheduleListViewModel.swift
@@ -22,7 +22,6 @@ final class WorkSpaceCreateScheduleListViewModel: ObservableObject {
 
         }
     }
-
     
     func didTapAddScheduleButton() {
         showModal()

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceCreateScheduleListViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceCreateScheduleListViewModel.swift
@@ -7,11 +7,21 @@
 
 import SwiftUI
 
-struct WorkSpaceCreateScheduleListViewModel: View {
-    var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+final class WorkSpaceCreateScheduleListViewModel: ObservableObject {
+    @Published var isNavigationActivated = false
+    @Published var scheduleList: [Schedule] = []
+    
+    func didTapAddScheduleButton() {
+        showModal()
     }
 }
+
+extension WorkSpaceCreateScheduleListViewModel {
+    func showModal() {
+        isShowingModal = true
+    }
+}
+
 struct Schedule: Hashable{
     var workDays: [String] = []
     var startHour: String = ""

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceCreateScheduleListViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceCreateScheduleListViewModel.swift
@@ -8,9 +8,21 @@
 import SwiftUI
 
 final class WorkSpaceCreateScheduleListViewModel: ObservableObject {
-    @Published var isNavigationActivated = false
-    @Published var scheduleList: [Schedule] = []
     @Published var isShowingModal = false
+    @Published var isShowingConfirmButton = false
+    
+    @Published var scheduleList: [Schedule] = [] {
+        didSet {
+            if !scheduleList.isEmpty {
+                isShowingConfirmButton = true
+            }
+            print("변경됨")
+            isShowingConfirmButton = true
+            print(isShowingConfirmButton)
+
+        }
+    }
+
     
     func didTapAddScheduleButton() {
         showModal()

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceCreateViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceCreateViewModel.swift
@@ -111,11 +111,3 @@ enum WritingState: Int {
         }
     }
 }
-
-//struct WorkSpaceInfo {
-//    var workSpaceName: String
-//    var hourlyWage: Int?
-//    var payday: Int
-//    var incomeTax: Bool
-//    var holidayAllowance: Bool
-//}


### PR DESCRIPTION
# 프로젝트 이미지 
(수정 및 구현 사항에 대한 간략한 캡쳐)
근무유형을 추가 할 수 있도록 만들었습니다.

|리스트 뷰|추가 뷰|추가 후의 리스트 뷰|
|---|---|---|
|![Simulator Screen Shot - iPhone 13 - 2022-10-24 at 15 39 42](https://user-images.githubusercontent.com/46256034/197463391-5dab74e3-7be3-45e7-b65c-1ce0517e838a.png)|![Simulator Screen Shot - iPhone 13 - 2022-10-24 at 15 39 23](https://user-images.githubusercontent.com/46256034/197463417-fe3aea6b-ab78-451c-ba22-d009e38d1254.png)|![Simulator Screen Shot - iPhone 13 - 2022-10-24 at 15 38 51](https://user-images.githubusercontent.com/46256034/197463435-9ea7411d-06f4-4593-92c1-15fc7339efb6.png)|



## 세부 사항
(여기에 수정 사항에 대한 자세한 내용을 작성해 주세요.)
- 인풋에 대한 케이스를 막는것을 구현중입니다.
- [ ] 시간이 겹치는 경우
- [x] 인풋을 모두 적지 않은 경우 00을 어떻게 보여줄지
- [x] 시작시간보다 끝나는 시간이 더 늦은경우 (새벽근무로 쳐서 계산할지 여부
- [ ] 컨포넌트 적용이 필요합니다. 해당 뷰의 컨포넌트가 붙을경우 지금의 모습과 달라질 것 입니다.
- [x] 다음화면으로 넘어가는 버튼을 근무유형이 하나라도 있을경우 생성되게 해야합니다.
- [x] 시간값을 24시간 이상 받으면 작성되지 않게 해야합니다.

## 기타 질문 및 특이 사항 + 논의사항
(궁금한 사항들, 하면서 느낀 점 및 공유할 내용)
- 모달로 들어가면서 지난 뷰의 데이터를 다음 뷰의 뷰모델로 넣는과정에서 어려움이 있어서 로직을 밖으로 뺐습니다. 해당 부분에 대한 조언이 필요합니다!!
- 24H 표기인것을 알려줄 필요가 있을것 같습니다.
- 혹은 버튼 탭 한번에 오전과 오후/ 00분과 30분을 토글하는것을 만드는 것도 좋아보입니다.
- 주말이라고 표현하는것에 대해서 합의가 명확한지 궁금합니다.
 
## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)
- [x]  필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x]  코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x]  제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x]  본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
