### PR TITLE
BD-72-등록확인ui구현-머지용-브랜치-추가(DB-28)

### DIFF
--- a/Rlog.xcodeproj/project.pbxproj
+++ b/Rlog.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2D16518F2907D5CE00636D61 /* TitleSubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D16518E2907D5CE00636D61 /* TitleSubView.swift */; };
+		2D1651912907D5F300636D61 /* WorkSpaceInfoSubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1651902907D5F300636D61 /* WorkSpaceInfoSubView.swift */; };
+		2D1651932907D61800636D61 /* WorkSpaceCreateConfirmationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1651922907D61800636D61 /* WorkSpaceCreateConfirmationView.swift */; };
+		2D1651952907D63300636D61 /* WorkSpaceCreateConfirmationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1651942907D63300636D61 /* WorkSpaceCreateConfirmationViewModel.swift */; };
 		2D66DCA228FD4DF000C90400 /* RlogApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D66DCA128FD4DF000C90400 /* RlogApp.swift */; };
 		2D66DCA628FD4DF200C90400 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2D66DCA528FD4DF200C90400 /* Assets.xcassets */; };
 		2D66DCA928FD4DF200C90400 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2D66DCA828FD4DF200C90400 /* Preview Assets.xcassets */; };
@@ -31,10 +35,10 @@
 		2D66DCDE28FD8EB300C90400 /* ScheduleUpdateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D66DCDD28FD8EB300C90400 /* ScheduleUpdateViewModel.swift */; };
 		2D66DCE028FD8ECA00C90400 /* MainTabViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D66DCDF28FD8ECA00C90400 /* MainTabViewModel.swift */; };
 		2D66DCE428FD8F1D00C90400 /* Color+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D66DCE328FD8F1D00C90400 /* Color+.swift */; };
-		B9239C812901467500197ECD /* ScheduleListView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9239C802901467500197ECD /* ScheduleListView+.swift */; };
 		75DE0162290271E600A77369 /* WorkSpaceCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75DE0161290271E600A77369 /* WorkSpaceCell.swift */; };
 		7A937596290035BD00D6D5BE /* FilledButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A937595290035BD00D6D5BE /* FilledButton.swift */; };
 		89CAA070290265F300504BDE /* StrokeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89CAA06F290265F300504BDE /* StrokeButton.swift */; };
+		B9239C812901467500197ECD /* ScheduleListView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9239C802901467500197ECD /* ScheduleListView+.swift */; };
 		C62C338C28FFCEBD00469273 /* CustomButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C62C338B28FFCEBD00469273 /* CustomButtonView.swift */; };
 		C64D97BA28FE918F004F80E7 /* Text+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C64D97B928FE918F004F80E7 /* Text+.swift */; };
 		C64D97BC28FE9197004F80E7 /* TextField+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C64D97BB28FE9197004F80E7 /* TextField+.swift */; };
@@ -56,6 +60,10 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		2D16518E2907D5CE00636D61 /* TitleSubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleSubView.swift; sourceTree = "<group>"; };
+		2D1651902907D5F300636D61 /* WorkSpaceInfoSubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkSpaceInfoSubView.swift; sourceTree = "<group>"; };
+		2D1651922907D61800636D61 /* WorkSpaceCreateConfirmationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkSpaceCreateConfirmationView.swift; sourceTree = "<group>"; };
+		2D1651942907D63300636D61 /* WorkSpaceCreateConfirmationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkSpaceCreateConfirmationViewModel.swift; sourceTree = "<group>"; };
 		2D66DC9E28FD4DF000C90400 /* Rlog.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Rlog.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2D66DCA128FD4DF000C90400 /* RlogApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RlogApp.swift; sourceTree = "<group>"; };
 		2D66DCA528FD4DF200C90400 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -81,10 +89,10 @@
 		2D66DCDD28FD8EB300C90400 /* ScheduleUpdateViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleUpdateViewModel.swift; sourceTree = "<group>"; };
 		2D66DCDF28FD8ECA00C90400 /* MainTabViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabViewModel.swift; sourceTree = "<group>"; };
 		2D66DCE328FD8F1D00C90400 /* Color+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+.swift"; sourceTree = "<group>"; };
-		B9239C802901467500197ECD /* ScheduleListView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ScheduleListView+.swift"; sourceTree = "<group>"; };
 		75DE0161290271E600A77369 /* WorkSpaceCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkSpaceCell.swift; sourceTree = "<group>"; };
 		7A937595290035BD00D6D5BE /* FilledButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilledButton.swift; sourceTree = "<group>"; };
 		89CAA06F290265F300504BDE /* StrokeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StrokeButton.swift; sourceTree = "<group>"; };
+		B9239C802901467500197ECD /* ScheduleListView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ScheduleListView+.swift"; sourceTree = "<group>"; };
 		C62C338B28FFCEBD00469273 /* CustomButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CustomButtonView.swift; path = Rlog/View/Components/CustomButtonView.swift; sourceTree = SOURCE_ROOT; };
 		C64D97B928FE918F004F80E7 /* Text+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Text+.swift"; sourceTree = "<group>"; };
 		C64D97BB28FE9197004F80E7 /* TextField+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TextField+.swift"; sourceTree = "<group>"; };
@@ -184,6 +192,7 @@
 				2D66DCC028FD8D5100C90400 /* WorkSpaceListView.swift */,
 				2D66DCC228FD8D6100C90400 /* WorkSpaceDetailView.swift */,
 				2D66DCC428FD8D6D00C90400 /* WorkSpaceCreateView.swift */,
+				2D1651922907D61800636D61 /* WorkSpaceCreateConfirmationView.swift */,
 			);
 			path = WorkSpace;
 			sourceTree = "<group>";
@@ -224,6 +233,7 @@
 				2D66DCD728FD8E7100C90400 /* WorkSpaceListViewModel.swift */,
 				2D66DCD928FD8E8F00C90400 /* WorkSpaceDetailViewModel.swift */,
 				2D66DCDB28FD8E9D00C90400 /* WorkSpaceCreateViewModel.swift */,
+				2D1651942907D63300636D61 /* WorkSpaceCreateConfirmationViewModel.swift */,
 			);
 			path = WorkSpace;
 			sourceTree = "<group>";
@@ -263,6 +273,8 @@
 			isa = PBXGroup;
 			children = (
 				75DE0161290271E600A77369 /* WorkSpaceCell.swift */,
+				2D16518E2907D5CE00636D61 /* TitleSubView.swift */,
+				2D1651902907D5F300636D61 /* WorkSpaceInfoSubView.swift */,
 			);
 			path = SubViews;
 			sourceTree = "<group>";
@@ -386,6 +398,7 @@
 				2D66DCC128FD8D5100C90400 /* WorkSpaceListView.swift in Sources */,
 				C64D97C728FE92C7004F80E7 /* DayEntity.swift in Sources */,
 				C67FC83B290693BD00DE3898 /* ScheduleEntity+CoreDataClass.swift in Sources */,
+				2D1651912907D5F300636D61 /* WorkSpaceInfoSubView.swift in Sources */,
 				2D66DCD028FD8E1000C90400 /* ScheduleCreateViewModel.swift in Sources */,
 				C62C338C28FFCEBD00469273 /* CustomButtonView.swift in Sources */,
 				2D66DCBB28FD8D0E00C90400 /* ScheduleListView.swift in Sources */,
@@ -398,6 +411,7 @@
 				2D66DCC328FD8D6100C90400 /* WorkSpaceDetailView.swift in Sources */,
 				2D66DCAE28FD4DF200C90400 /* DataModel.xcdatamodeld in Sources */,
 				C67FC836290692BD00DE3898 /* WorkDayEntity+CoreDataProperties.swift in Sources */,
+				2D16518F2907D5CE00636D61 /* TitleSubView.swift in Sources */,
 				2D66DCDE28FD8EB300C90400 /* ScheduleUpdateViewModel.swift in Sources */,
 				C64D97BE28FE919F004F80E7 /* Date+.swift in Sources */,
 				2D66DCCC28FD8DC500C90400 /* MainTabView.swift in Sources */,
@@ -406,6 +420,7 @@
 				C64D97C328FE92B0004F80E7 /* WorkspaceEntity.swift in Sources */,
 				2D66DCD628FD8E5500C90400 /* MonthlyCalculateDetailViewModel.swift in Sources */,
 				2D66DCD828FD8E7100C90400 /* WorkSpaceListViewModel.swift in Sources */,
+				2D1651932907D61800636D61 /* WorkSpaceCreateConfirmationView.swift in Sources */,
 				2D66DCC728FD8D8900C90400 /* MonthlyCalculateListView.swift in Sources */,
 				2D66DCCA28FD8DA200C90400 /* MonthlyCalculateDetailView.swift in Sources */,
 				75DE0162290271E600A77369 /* WorkSpaceCell.swift in Sources */,
@@ -417,6 +432,7 @@
 				C64D97C028FE91AB004F80E7 /* DateFormatter+.swift in Sources */,
 				2D66DCA228FD4DF000C90400 /* RlogApp.swift in Sources */,
 				C64D97BC28FE9197004F80E7 /* TextField+.swift in Sources */,
+				2D1651952907D63300636D61 /* WorkSpaceCreateConfirmationViewModel.swift in Sources */,
 				2D66DCBD28FD8D2500C90400 /* ScheduleCreateView.swift in Sources */,
 				2D66DCE028FD8ECA00C90400 /* MainTabViewModel.swift in Sources */,
 			);

--- a/Rlog/View/WorkSpace/SubViews/TitleSubView.swift
+++ b/Rlog/View/WorkSpace/SubViews/TitleSubView.swift
@@ -1,0 +1,22 @@
+//
+//  TitleSubView.swift
+//  Rlog
+//
+//  Created by 송시원 on 2022/10/19.
+//
+import SwiftUI
+
+struct TitleSubView: View {
+    let title: String
+    var body: some View {
+        Text(title)
+            .font(.title3)
+            .padding(.bottom,20)
+    }
+}
+
+struct TitleSubView_Previews: PreviewProvider {
+    static var previews: some View {
+        TitleSubView(title: "test")
+    }
+}

--- a/Rlog/View/WorkSpace/SubViews/WorkSpaceInfoSubView.swift
+++ b/Rlog/View/WorkSpace/SubViews/WorkSpaceInfoSubView.swift
@@ -1,0 +1,23 @@
+//
+//  WorkSpaceInfoSubView.swift
+//  Rlog
+//
+//  Created by 송시원 on 2022/10/19.
+//
+import SwiftUI
+
+struct WorkSpaceInfoSubView: View {
+    let labelName: String
+    let content: String
+
+    var body: some View {
+
+        VStack(alignment: .leading, spacing: 10) {
+            Text(labelName)
+                .font(.caption)
+                .foregroundColor(.fontLightGray)
+            Text(content)
+                .foregroundColor(.fontBlack)
+        }
+    }
+}

--- a/Rlog/View/WorkSpace/WorkSpaceCreateConfirmationView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceCreateConfirmationView.swift
@@ -1,0 +1,62 @@
+//
+//  WorkSpaceCreateConfirmationView.swift
+//  Rlog
+//
+//  Created by 송시원 on 2022/10/19.
+//
+// TODO: 네비게이션 연결, 뷰모델 연결, 고민 공유, 컨포넌트 적용
+import SwiftUI
+
+struct WorkSpaceCreateConfirmationView: View {
+    @ObservedObject private var viewModel = WorkSpaceCreateConfirmationViewModel()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            TitleSubView(title: "새로운 아르바이트를 추가합니다.")
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    WorkSpaceInfoSubView(labelName:"근무지", content:"팍이네 팍팍 감자탕")
+                    WorkSpaceInfoSubView(labelName:"시급", content:"9,250원")
+                    WorkSpaceInfoSubView(labelName:"급여일", content:"매월 10일")
+                    WorkSpaceInfoSubView(labelName:"주휴수당", content:viewModel.hasTax ? "60시간 근무 시 적용" : "미적용")
+                    WorkSpaceInfoSubView(labelName:"근무지", content:viewModel.hasJuhyu ? "3.3% 적용" : "미적용")
+                    WorkTypeInfo(for: "haha")
+                    Spacer()
+                }
+            }
+        }
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                toolbarConfirmButton
+            }
+        }
+        .padding()
+    }
+}
+
+private extension WorkSpaceCreateConfirmationView {
+    @ViewBuilder
+    func WorkTypeInfo(for worktype: String) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("근무 유형")
+                .font(.caption)
+                .foregroundColor(.fontLightGray)
+            // TODO: 컨포넌트에 일하는 유형을 넣어준다.
+            RoundedRectangle(cornerRadius: 10)
+                .frame(height: 54)
+        }
+    }
+    var toolbarConfirmButton: some View {
+            Button{
+                viewModel.didTapConfirmButton()
+            } label: {
+                Text("완료")
+            }
+        }
+}
+
+struct WorkSpaceCreateConfirmationView_Previews: PreviewProvider {
+    static var previews: some View {
+        WorkSpaceCreateConfirmationView()
+    }
+}

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceCreateConfirmationViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceCreateConfirmationViewModel.swift
@@ -1,0 +1,24 @@
+//
+//  WorkSpaceCreateConfirmationViewModel.swift
+//  Rlog
+//
+//  Created by 송시원 on 2022/10/25.
+//
+import SwiftUI
+
+final class WorkSpaceCreateConfirmationViewModel: ObservableObject {
+    let hasTax = false
+    let hasJuhyu = false
+    func didTapConfirmButton() {
+        popToRoot()
+        writeCoredata()
+    }
+}
+extension WorkSpaceCreateConfirmationViewModel {
+    func popToRoot() {
+        //https://stackoverflow.com/questions/57334455/how-can-i-pop-to-the-root-view-using-swiftui
+    }
+    func writeCoredata() {
+        // 코어데이터에 저장하는 함수를 구현
+    }
+}


### PR DESCRIPTION
# 프로젝트 이미지 
|시뮬레이터 캡쳐|피그마 파일|
|---|---|
|<img src="https://user-images.githubusercontent.com/46256034/196706767-601a591b-ec2e-4488-b8fe-c99cfb66601b.png" width="276" />|<img width="276" alt="image" src="https://user-images.githubusercontent.com/46256034/196707982-d01a590d-7df6-4329-8ab9-476b9018c8e4.png">|



## 세부 사항
- 등록 확인 유아이를 구현하였습니다.
- 타이틀 같은 경우, 생성 과정을 반복할 것으로 생각되어 재사용 가능성을 염두에 두어 만들었습니다.
- 파일 구조를 분리하기위해 섭뷰 그룹을 두었는데 이에 대해 어떻게 생각하시는지 궁금합니다!
- 근무지 정보유아이는 반복되는 정보를 같은 패턴에 담고있어서 해당 내용을 직접 보여주는 섭뷰로 작업했습니다.
- 근무 유형의 경우, 컨포넌트를 받아서 사용할 예정이기 때문에 이 부분은 뷰빌더로 제작하였습니다.


### 해당 뷰와 관련해서 남은 할 일
- [ ] 네비게이션 연결
- [ ] 요일을 담는 컨포넌트 적용

 
## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)
- [x]  필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x]  코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x]  제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x]  본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
