### PR TITLE
BD-17 CustomTextField의 parameter 타입을 generic 으로 변경합니다.

### DIFF
--- a/Rlog/View/Components/InputFormElement.swift
+++ b/Rlog/View/Components/InputFormElement.swift
@@ -7,11 +7,11 @@
 
 import SwiftUI
 
-struct InputFormElement: View {
+struct InputFormElement<T>: View {
     let containerType: UnderlinedTextFieldType
-    var text: Binding<String>
+    var text: Binding<T>
     
-    init(containerType: UnderlinedTextFieldType, text: Binding<String>) {
+    init(containerType: UnderlinedTextFieldType, text: Binding<T>) {
         self.containerType = containerType
         self.text = text
     }
@@ -51,8 +51,8 @@ private extension InputFormElement {
                 textFieldType: .workplace,
                 text: text
             )
-            
-            if text.wrappedValue.count > 20 {
+
+            if let text = text.wrappedValue as? String, text.count > 20 {
                 HStack {
                     Text("20자 이상 입력할 수 없어요.")
                         .font(.footnote)
@@ -86,7 +86,7 @@ private extension InputFormElement {
                     text: text
                 )
                 
-                if Int(text.wrappedValue) ?? 10 > 28 {
+                if let number = text.wrappedValue as? Int16, number > 28 || number < 1 {
                     HStack {
                         Text("1~28 사이의 숫자를 입력해주세요")
                             .font(.footnote)
@@ -98,6 +98,7 @@ private extension InputFormElement {
                 
             }
             Spacer()
+            
             Text("일")
         }
     }
@@ -107,7 +108,6 @@ private extension InputFormElement {
             textFieldType: .reason,
             text: text
         )
-        
     }
     
     var noneView: some View {

--- a/Rlog/View/Components/UnderlinedTextField.swift
+++ b/Rlog/View/Components/UnderlinedTextField.swift
@@ -123,7 +123,7 @@ private struct UITextFieldRepresentable<T>: UIViewRepresentable {
     }
     
     func updateUIView(_ uiView: UITextField, context: UIViewRepresentableContext<UITextFieldRepresentable>) {
-        uiView.text = String(describing: self.text)
+        uiView.text = "\(self.text)"
         if isFirstResponder && !context.coordinator.didFirstResponder {
             uiView.becomeFirstResponder()
             context.coordinator.didFirstResponder = true


### PR DESCRIPTION
# 프로젝트 이미지 
<div>
<img width="486" alt="스크린샷 2022-10-26 15 36 31" src="https://user-images.githubusercontent.com/88080251/197952534-f401de4d-9f6c-404b-9809-3adcbfc9088b.png">
</div>
<img width="343" alt="스크린샷 2022-10-26 15 36 48" src="https://user-images.githubusercontent.com/88080251/197952579-910f31ff-5202-4f6f-99cb-ee7d485c0389.png">


## 세부 사항
아래와 같이 사용해주세요.
```swift
            UnderlinedTextField(textFieldType: .workplace, text: $text)
            InputFormElement(containerType: .workplace, text: $number)
```

✅✅✅ 기존 Binding String 에서 Binding T로 타입을 변경한 이유 ✅✅✅
데이터가 Input되는 과정에서 다양한 타입을 대응할 수 있도록 변경했습니다..!
근무지 관련 데이터 중 근무지는 String, 급여일 혹은 시급의 경우에는 Int16으로 취급합니다.
상이한 데이터 타입을 TextField로 주입할 때에는 String으로 변환할 필요가 있어 Generic을 사용하게 되었습니다.

## 기타 질문 및 특이 사항
- N/A
 
## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)
- [x]  필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x]  코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x]  제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x]  본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
