### PR TITLE
BD-103-work-day-entity-의-spent-hour-을-int-16-double-로-수정

### DIFF
--- a/Rlog/CoreData/CoreDataManager.swift
+++ b/Rlog/CoreData/CoreDataManager.swift
@@ -115,7 +115,7 @@ extension CoreDataManager {
     }
 
     // MARK: - WORKDAY CRUD
-    func createWorkday(of workspace: WorkspaceEntity, weekDay: Int16, yearInt: Int16, monthInt: Int16, dayInt: Int16, startTime: String, endTime: String, spentHour: Int16, workDayType: Int16) {
+    func createWorkday(of workspace: WorkspaceEntity, weekDay: Int16, yearInt: Int16, monthInt: Int16, dayInt: Int16, startTime: String, endTime: String, spentHour: Double, workDayType: Int16) {
         let workday = WorkDayEntity(context: context)
         workday.workspace = workspace
         workday.id = UUID()
@@ -159,7 +159,7 @@ extension CoreDataManager {
         return result ?? []
     }
 
-    func editWorkday(of workday: WorkDayEntity, weekDay: Int16, yearInt: Int16, monthInt: Int16, dayInt: Int16, startTime: String, endTime: String, spentHour: Int16, hasDone: Bool) {
+    func editWorkday(of workday: WorkDayEntity, weekDay: Int16, yearInt: Int16, monthInt: Int16, dayInt: Int16, startTime: String, endTime: String, spentHour: Double, hasDone: Bool) {
         workday.weekDay = weekDay
         workday.workDayType = workDayType
         workday.yearInt = yearInt

--- a/Rlog/CoreData/DataModel.xcdatamodeld/Rlog.xcdatamodel/contents
+++ b/Rlog/CoreData/DataModel.xcdatamodeld/Rlog.xcdatamodel/contents
@@ -16,7 +16,7 @@
         <attribute name="hasDone" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="monthInt" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
-        <attribute name="spentHour" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="spentHour" attributeType="Double" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="startHour" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="startMinute" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="weekDay" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>

--- a/Rlog/Model/CoreData/WorkDayEntity+CoreDataProperties.swift
+++ b/Rlog/Model/CoreData/WorkDayEntity+CoreDataProperties.swift
@@ -25,7 +25,7 @@ extension WorkDayEntity {
     @NSManaged public var startMinute: Int16
     @NSManaged public var endHour: Int16
     @NSManaged public var endMinute: Int16
-    @NSManaged public var spentHour: Int16
+    @NSManaged public var spentHour: Double
 
     @NSManaged public var hasDone: Bool
     @NSManaged public var workDayType: Int16


### PR DESCRIPTION
# 프로젝트 이미지 
(수정 및 구현 사항에 대한 간략한 캡쳐)

## 세부 사항
(여기에 수정 사항에 대한 자세한 내용을 작성해 주세요.)
- WorkDayEntity의 spentHour 을 Int16 에서 Double 수정하였습니다
- 1시간 30분 -> 1.5시간으로 기록함으로써 나중에 정산뷰에서 계산 로직 구현을 위해 바꿨습니다

## 기타 질문 및 특이 사항
(궁금한 사항들, 하면서 느낀 점 및 공유할 내용)
-
-
 
## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)
- [x]  필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x]  코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x]  제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x]  본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
