### PR TITLE
Bd 23 cell 제외 UI 구현 전체 정산 달

### DIFF
--- a/Rlog/Extension/Date+.swift
+++ b/Rlog/Extension/Date+.swift
@@ -22,4 +22,8 @@ extension Date {
         let converted = dateFormatter.string(from: date)
         return converted
     }
+    
+    func fetchMonth() -> String {
+        return String(Calendar.current.component(.month, from: date))
+    }
 }

--- a/Rlog/Extension/Date+.swift
+++ b/Rlog/Extension/Date+.swift
@@ -24,6 +24,6 @@ extension Date {
     }
     
     func fetchMonth() -> String {
-        return String(Calendar.current.component(.month, from: date))
+        return String(Calendar.current.component(.month, from: self))
     }
 }

--- a/Rlog/View/MonthlyCalculate/MonthlyCalculateListView.swift
+++ b/Rlog/View/MonthlyCalculate/MonthlyCalculateListView.swift
@@ -9,6 +9,39 @@ import SwiftUI
 
 struct MonthlyCalculateListView: View {
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        VStack(spacing: 0) {
+            header
+                .padding(.top, 24)
+            Spacer()
+        }
+        .padding(.horizontal)
+    }
+}
+
+private extension MonthlyCalculateListView {
+    var header: some View {
+        HStack {
+            Text("정산")
+                .font(.title2)
+                .fontWeight(.bold)
+            Spacer()
+            HStack(spacing: 8) {
+                Button(action: {
+                    // TODO: - ViewModel에서 로직 구현
+                }, label: {
+                    Image(systemName: "chevron.left")
+                })
+                // TODO: - 현재 연도, 월로 바꾸기
+                Text("2022.11")
+                    .fontWeight(.bold)
+                Button(action: {
+                    // TODO: - ViewModel에서 로직 구현
+                }, label: {
+                    Image(systemName: "chevron.right")
+                })
+            }
+            .font(.title)
+            .foregroundColor(.black)
+        }
     }
 }

--- a/Rlog/View/MonthlyCalculate/MonthlyCalculateListView.swift
+++ b/Rlog/View/MonthlyCalculate/MonthlyCalculateListView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct MonthlyCalculateListView: View {
+    @ObservedObject private var viewModel = MonthlyCalculateListViewModel()
+    
     var body: some View {
         VStack(spacing: 0) {
             header
@@ -34,7 +36,7 @@ private extension MonthlyCalculateListView {
                     Image(systemName: "chevron.left")
                 })
                 // TODO: - 현재 연도, 월로 바꾸기
-                Text("2022.11")
+                Text("\(viewModel.fecthYear()).\(viewModel.fetchMonth())")
                     .fontWeight(.bold)
                 Button(action: {
                     // TODO: - ViewModel에서 로직 구현
@@ -49,7 +51,7 @@ private extension MonthlyCalculateListView {
     
     var total: some View {
         HStack {
-            Text("11월 총 금액")
+            Text("\(viewModel.fetchMonth())월 총 금액")
             Spacer()
             Text("10,200,000원")
                 .fontWeight(.bold)

--- a/Rlog/View/MonthlyCalculate/MonthlyCalculateListView.swift
+++ b/Rlog/View/MonthlyCalculate/MonthlyCalculateListView.swift
@@ -37,7 +37,7 @@ private extension MonthlyCalculateListView {
                 })
                 // TODO: - 현재 연도, 월로 바꾸기
                 Text("\(viewModel.fecthYear()).\(viewModel.fetchMonth())")
-                    .fontWeight(.bold)
+                    .fontWeight(.semibold)
                 Button(action: {
                     // TODO: - ViewModel에서 로직 구현
                 }, label: {

--- a/Rlog/View/MonthlyCalculate/MonthlyCalculateListView.swift
+++ b/Rlog/View/MonthlyCalculate/MonthlyCalculateListView.swift
@@ -29,6 +29,7 @@ private extension MonthlyCalculateListView {
                 .font(.title2)
                 .fontWeight(.bold)
             Spacer()
+            // TODO: - 컴포넌트화 예정
             HStack(spacing: 8) {
                 Button(action: {
                     // TODO: - ViewModel에서 로직 구현
@@ -36,7 +37,7 @@ private extension MonthlyCalculateListView {
                     Image(systemName: "chevron.left")
                 })
                 // TODO: - 현재 연도, 월로 바꾸기
-                Text("\(viewModel.fecthYear()).\(viewModel.fetchMonth())")
+                Text(viewModel.date.fetchYearAndMonth())
                     .fontWeight(.semibold)
                 Button(action: {
                     // TODO: - ViewModel에서 로직 구현

--- a/Rlog/View/MonthlyCalculate/MonthlyCalculateListView.swift
+++ b/Rlog/View/MonthlyCalculate/MonthlyCalculateListView.swift
@@ -46,17 +46,18 @@ private extension MonthlyCalculateListView {
                 })
             }
             .font(.title)
-            .foregroundColor(.black)
         }
+        .foregroundColor(Color.fontBlack)
     }
     
     var total: some View {
         HStack {
-            Text("\(viewModel.fetchMonth())월 총 금액")
+            Text("\(viewModel.date.fetchMonth())월 총 금액")
             Spacer()
             Text("10,200,000원")
                 .fontWeight(.bold)
         }
         .font(.title3)
+        .foregroundColor(Color.fontBlack)
     }
 }

--- a/Rlog/View/MonthlyCalculate/MonthlyCalculateListView.swift
+++ b/Rlog/View/MonthlyCalculate/MonthlyCalculateListView.swift
@@ -12,6 +12,8 @@ struct MonthlyCalculateListView: View {
         VStack(spacing: 0) {
             header
                 .padding(.top, 24)
+            total
+                .padding(.top, 34)
             Spacer()
         }
         .padding(.horizontal)
@@ -43,5 +45,15 @@ private extension MonthlyCalculateListView {
             .font(.title)
             .foregroundColor(.black)
         }
+    }
+    
+    var total: some View {
+        HStack {
+            Text("11월 총 금액")
+            Spacer()
+            Text("10,200,000원")
+                .fontWeight(.bold)
+        }
+        .font(.title3)
     }
 }

--- a/Rlog/ViewModel/MonthlyCalculate/MonthlyCalculateListViewModel.swift
+++ b/Rlog/ViewModel/MonthlyCalculate/MonthlyCalculateListViewModel.swift
@@ -9,5 +9,13 @@ import Foundation
 
 @MainActor
 final class MonthlyCalculateListViewModel: ObservableObject {
+    @Published var date = Date()
     
+    func fecthYear() -> String {
+        return String(Calendar.current.component(.year, from: date))
+    }
+    
+    func fetchMonth() -> String {
+        return String(Calendar.current.component(.month, from: date))
+    }
 }

--- a/Rlog/ViewModel/MonthlyCalculate/MonthlyCalculateListViewModel.swift
+++ b/Rlog/ViewModel/MonthlyCalculate/MonthlyCalculateListViewModel.swift
@@ -10,12 +10,4 @@ import Foundation
 @MainActor
 final class MonthlyCalculateListViewModel: ObservableObject {
     @Published var date = Date()
-    
-    func fecthYear() -> String {
-        return String(Calendar.current.component(.year, from: date))
-    }
-    
-    func fetchMonth() -> String {
-        return String(Calendar.current.component(.month, from: date))
-    }
 }


### PR DESCRIPTION
# 프로젝트 이미지 
(수정 및 구현 사항에 대한 간략한 캡쳐)

<img src="https://user-images.githubusercontent.com/103025692/201298259-4e233a09-9451-46d0-9cdf-c2797af1f4ed.png" width=275 />

## 세부 사항

(여기에 수정 사항에 대한 자세한 내용을 작성해 주세요.)
- 정산 뷰 중에서 전체 정산 현황을 보는 뷰의 상단 헤더의 UI를 구현했습니다.
- 우상단의 연도와 월, 좌하단의 월을 나타내는 부분까지 실제 연도와 월을 가져와서 구현했습니다.

## 기타 질문 및 특이 사항
(궁금한 사항들, 하면서 느낀 점 및 공유할 내용)
- 우상단 버튼의 크기를 정확하게 알려주시면 감사하겠습니다.
 
## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)
- [x]  필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x]  코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x]  제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x]  본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
