### PR TITLE
Bd 189 core data manager crud 작동 확인

### DIFF
--- a/Rlog/View/Components/ScheduleContainer.swift
+++ b/Rlog/View/Components/ScheduleContainer.swift
@@ -14,6 +14,8 @@ struct ScheduleContainer: View {
     let endHour: String
     let endMinute: String
     
+    var completion: (() -> Void)?
+    
     var body: some View {
         scheduleContainerView
     }
@@ -40,7 +42,11 @@ private extension ScheduleContainer {
             
             workHourView
             
-            Button{} label: {
+            Button{
+                if let completion = completion {
+                    completion()
+                }
+            } label: {
                 Image(systemName: "minus.circle")
                     .foregroundColor(.red)
             }.padding(.leading)

--- a/Rlog/View/MonthlyCalculate/MonthlyCalculateListView.swift
+++ b/Rlog/View/MonthlyCalculate/MonthlyCalculateListView.swift
@@ -23,6 +23,9 @@ struct MonthlyCalculateListView: View {
             }
             .padding(.horizontal)
         }
+        .onAppear {
+            viewModel.onAppear()
+        }
     }
 }
 
@@ -70,18 +73,9 @@ private extension MonthlyCalculateListView {
             ForEach(viewModel.workspaces, id: \.self) { workspace in
                 makeMonthlyCalculateListViewModel(workspace: workspace)
             }
-//            ForEach(1..<3) { _ in
-//                CalculateByWorkspaceCell()
-//            }
         }
     }
     
-    /* MARK: - 근무지에 해당하는 셀을 하위 struct로 만들어서 각 struct의 ViewModel이 값을 계산하게 할지 아니면 이 뷰가 전부 가지고 있을지를 고민하고 있습니다.
-     따로 struct를 빼버리면, 근무지 별로 필요한 WorkDay를 갖고 있으므로, 코드와 데이터 처리가 깔끔해질 것 같고, 전체 금액 계산하기가 껄끄러워 질 수도 있을 것 같습니다.
-     그래서, @escaping으로 계산 결과를 돌려 받아 월 전체 금액을 계산할지
-     이 뷰가 그냥 함수형이나 변수로 뷰를 가지고 있으면 전체 월 계산이 편해지지 않을까까지 고민해봤습니다.
-    */
-    // TODO: - 하위 Struct가 아닌, function으로 처리할 예정, 정산 결과 관련된 로직은 아예 다른 Service로 뺄 예정
     func makeMonthlyCalculateListViewModel(workspace: WorkspaceEntity) -> some View {
         var workspaceTitle: some View {
             HStack(spacing: 4) {

--- a/Rlog/View/MonthlyCalculate/MonthlyCalculateListView.swift
+++ b/Rlog/View/MonthlyCalculate/MonthlyCalculateListView.swift
@@ -67,9 +67,12 @@ private extension MonthlyCalculateListView {
     
     var calculateByWorkspaceList: some View {
         VStack {
-            ForEach(1..<3) { _ in
-                CalculateByWorkspaceCell()
+            ForEach(viewModel.workspaces, id: \.self) { workspace in
+                makeMonthlyCalculateListViewModel(workspace: workspace)
             }
+//            ForEach(1..<3) { _ in
+//                CalculateByWorkspaceCell()
+//            }
         }
     }
     
@@ -79,42 +82,13 @@ private extension MonthlyCalculateListView {
      이 뷰가 그냥 함수형이나 변수로 뷰를 가지고 있으면 전체 월 계산이 편해지지 않을까까지 고민해봤습니다.
     */
     // TODO: - 하위 Struct가 아닌, function으로 처리할 예정, 정산 결과 관련된 로직은 아예 다른 Service로 뺄 예정
-    private struct CalculateByWorkspaceCell: View {
-        var body: some View {
-            NavigationLink(destination: MonthlyCalculateDetailView()) {
-                VStack(alignment: .leading, spacing: 0) {
-                    workspaceTitle
-                        .padding(.top)
-                    Group {
-                        makeWorkspaceInfomation(title: "일한 시간", content: "32시간")
-                            .padding(.top, 32)
-
-                        makeWorkspaceInfomation(title: "급여일까지", content: "D-12")
-                            .padding(.top, 8)
-                        
-                        HDivider()
-                            .padding(.top, 8)
-                        
-                        calculateResult
-                            .padding(.vertical)
-                    }
-                    .padding(.leading, 4)
-                }
-                .padding(.horizontal)
-                .background(Color.backgroundCard)
-                .cornerRadius(8)
-                .padding(2)
-                .background(Color.backgroundStroke)
-                .clipShape(RoundedRectangle(cornerRadius: 10))
-            }
-        }
-        
+    func makeMonthlyCalculateListViewModel(workspace: WorkspaceEntity) -> some View {
         var workspaceTitle: some View {
             HStack(spacing: 4) {
                 Rectangle()
                     .fill(Color.primary)
                     .frame(width: 4, height: 16)
-                Text("GS25 포항공대점")
+                Text(workspace.name)
                     .fontWeight(.bold)
                     .foregroundColor(Color.fontBlack)
             }
@@ -142,6 +116,33 @@ private extension MonthlyCalculateListView {
                     .foregroundColor(Color.grayDark)
             }
             .font(.subheadline)
+        }
+        
+        return NavigationLink(destination: MonthlyCalculateDetailView()) {
+            VStack(alignment: .leading, spacing: 0) {
+                workspaceTitle
+                    .padding(.top)
+                Group {
+                    makeWorkspaceInfomation(title: "일한 시간", content: "32시간")
+                        .padding(.top, 32)
+                    
+                    makeWorkspaceInfomation(title: "급여일까지", content: "D-12")
+                        .padding(.top, 8)
+                    
+                    HDivider()
+                        .padding(.top, 8)
+                    
+                    calculateResult
+                        .padding(.vertical)
+                }
+                .padding(.leading, 4)
+            }
+            .padding(.horizontal)
+            .background(Color.backgroundCard)
+            .cornerRadius(8)
+            .padding(2)
+            .background(Color.backgroundStroke)
+            .clipShape(RoundedRectangle(cornerRadius: 10))
         }
     }
 }

--- a/Rlog/View/MonthlyCalculate/MonthlyCalculateListView.swift
+++ b/Rlog/View/MonthlyCalculate/MonthlyCalculateListView.swift
@@ -17,8 +17,10 @@ struct MonthlyCalculateListView: View {
                     .padding(.top, 24)
                 total
                     .padding(.top, 34)
-                calculateByWorkspaceList
-                    .padding(.top, 32)
+                ScrollView {
+                    calculateByWorkspaceList
+                        .padding(.top, 32)
+                }
                 Spacer()
             }
             .padding(.horizontal)

--- a/Rlog/View/MonthlyCalculate/MonthlyCalculateListView.swift
+++ b/Rlog/View/MonthlyCalculate/MonthlyCalculateListView.swift
@@ -25,9 +25,6 @@ struct MonthlyCalculateListView: View {
             }
             .padding(.horizontal)
         }
-        .onAppear {
-            viewModel.onAppear()
-        }
     }
 }
 

--- a/Rlog/View/MonthlyCalculate/MonthlyCalculateListView.swift
+++ b/Rlog/View/MonthlyCalculate/MonthlyCalculateListView.swift
@@ -24,6 +24,9 @@ struct MonthlyCalculateListView: View {
                 Spacer()
             }
             .padding(.horizontal)
+            .onAppear {
+                viewModel.onAppear()
+            }
         }
     }
 }

--- a/Rlog/View/WorkSpace/SubViews/WorkSpaceCell.swift
+++ b/Rlog/View/WorkSpace/SubViews/WorkSpaceCell.swift
@@ -8,8 +8,14 @@
 import SwiftUI
 
 struct WorkSpaceCell: View {
+    @ObservedObject private var viewModel: WorkSpaceCellViewModel
     
     var workspace: WorkspaceEntity
+    
+    init(workspace: WorkspaceEntity) {
+        self.workspace = workspace
+        viewModel = WorkSpaceCellViewModel(workspace: workspace)
+    }
     
     var body: some View {
         NavigationLink {
@@ -33,34 +39,33 @@ private extension WorkSpaceCell {
         }
     }
     
-    //TODO : 뷰모델 연동시 사용 예정
-    //    func makeWorkSpaceScheduleInfo() -> some View {
-    //        HStack(alignment: .top, spacing: 0) {
-    //            Text("workTitle")
-    //                .font(.subheadline)
-    //                .foregroundColor(.grayMedium)
-    //            Spacer()
-    //            VStack(spacing: 0) {
-    //                ForEach(schedules) { schedule in
-    //                    HStack(spacing: 0) {
-    //                        HStack(spacing: 0) {
-    //                            ForEach(schedule.repeatedSchedule, id:\.self) { week in
-    //                                Text(week)
-    //                                    .font(.subheadline)
-    //                                    .foregroundColor(.fontBlack)
-    //                                    .padding(.horizontal, 1)
-    //                            }
-    //                        }
-    //                        .padding(.trailing, 3)
-    //
-    //                        Text("\(schedule.startHour):\(schedule.startMinute)0 - \(schedule.endHour):\(schedule.endMinute)0")
-    //                            .font(.subheadline)
-    //                            .foregroundColor(.fontBlack)
-    //                    }
-    //                }
-    //            }
-    //        }
-    //    }
+    func makeWorkSpaceScheduleInfo(workTitle: String) -> some View {
+        HStack(alignment: .top, spacing: 0) {
+            Text(workTitle)
+                .font(.subheadline)
+                .foregroundColor(.grayMedium)
+            Spacer()
+            VStack(alignment: .trailing, spacing: 0) {
+                ForEach(viewModel.schedules, id: \.self) { schedule in
+                    HStack(spacing: 0) {
+                        HStack(spacing: 0) {
+                            ForEach(schedule.repeatDays, id: \.self) { week in
+                                Text(week)
+                                    .font(.subheadline)
+                                    .foregroundColor(.fontBlack)
+                                    .padding(.horizontal, 1)
+                            }
+                        }
+                        .padding(.trailing, 3)
+                        
+                        Text("\(schedule.startHour):\(schedule.startMinute)0 - \(schedule.endHour):\(schedule.endMinute)0")
+                            .font(.subheadline)
+                            .foregroundColor(.fontBlack)
+                    }
+                }
+            }
+        }
+    }
     
     func makeWorkSpaceCardContent(workspace: WorkspaceEntity) -> some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -80,7 +85,7 @@ private extension WorkSpaceCell {
                 makeWorkSpaceRowInfo(workTitle: "급여일", workInfo: "매월 \(String(workspace.payDay)) 일")
                 makeWorkSpaceRowInfo(workTitle: "주휴수당", workInfo: workspace.hasJuhyu ? "적용" : "미적용")
                 makeWorkSpaceRowInfo(workTitle: "소득세", workInfo: workspace.hasTax ? "적용" : "미적용")
-//                makeWorkSpaceScheduleInfo(workTitle: "근무유형", schedules: workspace.schedules)
+                makeWorkSpaceScheduleInfo(workTitle: "근무유형")
             }
         }
         .padding()

--- a/Rlog/View/WorkSpace/SubViews/WorkSpaceCell.swift
+++ b/Rlog/View/WorkSpace/SubViews/WorkSpaceCell.swift
@@ -9,13 +9,13 @@ import SwiftUI
 
 struct WorkSpaceCell: View {
     
-    var model: CustomModel
+    var workspace: WorkspaceEntity
     
     var body: some View {
         NavigationLink {
             WorkSpaceDetailView()
         } label: {
-            makeWorkSpaceCardContent(model: model)
+            makeWorkSpaceCardContent(workspace: workspace)
         }
     }
 }
@@ -62,13 +62,13 @@ private extension WorkSpaceCell {
     //        }
     //    }
     
-    func makeWorkSpaceCardContent(model: CustomModel) -> some View {
+    func makeWorkSpaceCardContent(workspace: WorkspaceEntity) -> some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack(alignment: .center){
                 Rectangle()
                     .foregroundColor(Color.primary)
                     .frame(width: 4, height: 16)
-                Text(model.name)
+                Text(workspace.name)
                     .font(.body)
                     .fontWeight(.bold)
                     .foregroundColor(.fontBlack)
@@ -76,11 +76,11 @@ private extension WorkSpaceCell {
             .padding(.bottom, 16)
             
             VStack(spacing: 8){
-                makeWorkSpaceRowInfo(workTitle: "시급", workInfo: "\(String(model.hourlyWage)) 원")
-                makeWorkSpaceRowInfo(workTitle: "급여일", workInfo: "매월 \(String(model.paymentDay)) 일")
-                makeWorkSpaceRowInfo(workTitle: "주휴수당", workInfo: model.hasJuhyu ? "적용" : "미적용")
-                makeWorkSpaceRowInfo(workTitle: "소득세", workInfo: model.hasTax ? "적용" : "미적용")
-                //                makeWorkSpaceScheduleInfo(workTitle: "근무유형", schedules: schedules)
+                makeWorkSpaceRowInfo(workTitle: "시급", workInfo: "\(String(workspace.hourlyWage)) 원")
+                makeWorkSpaceRowInfo(workTitle: "급여일", workInfo: "매월 \(String(workspace.payDay)) 일")
+                makeWorkSpaceRowInfo(workTitle: "주휴수당", workInfo: workspace.hasJuhyu ? "적용" : "미적용")
+                makeWorkSpaceRowInfo(workTitle: "소득세", workInfo: workspace.hasTax ? "적용" : "미적용")
+//                makeWorkSpaceScheduleInfo(workTitle: "근무유형", schedules: workspace.schedules)
             }
         }
         .padding()

--- a/Rlog/View/WorkSpace/SubViews/WorkSpaceCell.swift
+++ b/Rlog/View/WorkSpace/SubViews/WorkSpaceCell.swift
@@ -19,7 +19,7 @@ struct WorkSpaceCell: View {
     
     var body: some View {
         NavigationLink {
-            WorkSpaceDetailView()
+            WorkSpaceDetailView(workspace: viewModel.workspace)
         } label: {
             makeWorkSpaceCardContent(workspace: workspace)
         }

--- a/Rlog/View/WorkSpace/WorkSpaceDetailView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceDetailView.swift
@@ -107,8 +107,10 @@ struct WorkSpaceDetailView: View {
                 }
             }
         }
-        .sheet(isPresented: $viewModel.isCreateScheduleModalShow) {
-            Text("근무 패턴 생성")
+        .sheet(isPresented: $viewModel.isCreateScheduleModalShow, onDismiss: {
+            print("1")
+        }) {
+            WorkSpaceCreateCreatingScheduleView(isShowingModal: $viewModel.isCreateScheduleModalShow, scheduleList: $viewModel.schedulesDummy)
         }
         .background(Color.backgroundWhite)
         .navigationBarBackButtonHidden()

--- a/Rlog/View/WorkSpace/WorkSpaceDetailView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceDetailView.swift
@@ -46,12 +46,14 @@ struct WorkSpaceDetailView: View {
                 
                 ForEach(viewModel.schedules, id: \.self) { schedule in
                     ScheduleContainer(
-                        repeatedSchedule: schedule.repeatedSchedule,
-                        startHour: schedule.startHour,
-                        startMinute: schedule.startMinute,
-                        endHour: schedule.endHour,
-                        endMinute: schedule.endMinute
-                    )
+                        repeatedSchedule: schedule.repeatDays,
+                        startHour: String(schedule.startHour),
+                        startMinute: String(schedule.startMinute),
+                        endHour: String(schedule.endHour),
+                        endMinute: String(schedule.endMinute)
+                    ) {
+                        viewModel.didTapDeleteScheduleButton(schedule: schedule)
+                    }
                 }
                 .padding(.bottom, -8)
                 
@@ -113,7 +115,8 @@ struct WorkSpaceDetailView: View {
         .sheet(isPresented: $viewModel.isCreateScheduleModalShow, onDismiss: {
             print("1")
         }) {
-            WorkSpaceCreateCreatingScheduleView(isShowingModal: $viewModel.isCreateScheduleModalShow, scheduleList: $viewModel.schedules)
+            Text("WorkSpaceCreateCreatingScheduleView")
+//            WorkSpaceCreateCreatingScheduleView(isShowingModal: $viewModel.isCreateScheduleModalShow, scheduleList: $viewModel.schedules)
         }
         .background(Color.backgroundWhite)
         .navigationBarBackButtonHidden()

--- a/Rlog/View/WorkSpace/WorkSpaceDetailView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceDetailView.swift
@@ -57,14 +57,16 @@ struct WorkSpaceDetailView: View {
                 }
                 .padding(.bottom, -8)
                 
-                ForEach(viewModel.shouldCreateSchdeules, id: \.self) { schedule in
+                ForEach(viewModel.shouldCreateSchedules, id: \.self) { schedule in
                     ScheduleContainer(
                         repeatedSchedule: schedule.repeatedSchedule,
                         startHour: schedule.startHour,
                         startMinute: schedule.startMinute,
                         endHour: schedule.endHour,
                         endMinute: schedule.endMinute
-                    )
+                    ) {
+                        viewModel.didTapDeleteScheduleModelButton(schedule: schedule)
+                    }
                 }
                 .padding(.bottom, -8)
                 
@@ -126,7 +128,7 @@ struct WorkSpaceDetailView: View {
         .sheet(isPresented: $viewModel.isCreateScheduleModalShow, onDismiss: {
             print("1")
         }) {
-            WorkSpaceCreateCreatingScheduleView(isShowingModal: $viewModel.isCreateScheduleModalShow, scheduleList: $viewModel.shouldCreateSchdeules)
+            WorkSpaceCreateCreatingScheduleView(isShowingModal: $viewModel.isCreateScheduleModalShow, scheduleList: $viewModel.shouldCreateSchedules)
         }
         .background(Color.backgroundWhite)
         .navigationBarBackButtonHidden()

--- a/Rlog/View/WorkSpace/WorkSpaceDetailView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceDetailView.swift
@@ -46,11 +46,11 @@ struct WorkSpaceDetailView: View {
                 
                 ForEach(viewModel.schedules, id: \.self) { schedule in
                     ScheduleContainer(
-                        repeatedSchedule: schedule.repeatDays,
-                        startHour: String(schedule.startHour),
-                        startMinute: String(schedule.startMinute),
-                        endHour: String(schedule.endHour),
-                        endMinute: String(schedule.endMinute)
+                        repeatedSchedule: schedule.repeatedSchedule,
+                        startHour: schedule.startHour,
+                        startMinute: schedule.startMinute,
+                        endHour: schedule.endHour,
+                        endMinute: schedule.endMinute
                     )
                 }
                 .padding(.bottom, -8)
@@ -113,13 +113,10 @@ struct WorkSpaceDetailView: View {
         .sheet(isPresented: $viewModel.isCreateScheduleModalShow, onDismiss: {
             print("1")
         }) {
-            WorkSpaceCreateCreatingScheduleView(isShowingModal: $viewModel.isCreateScheduleModalShow, scheduleList: $viewModel.schedulesDummy)
+            WorkSpaceCreateCreatingScheduleView(isShowingModal: $viewModel.isCreateScheduleModalShow, scheduleList: $viewModel.schedules)
         }
         .background(Color.backgroundWhite)
         .navigationBarBackButtonHidden()
-        .onAppear {
-            viewModel.onAppear()
-        }
     }
 }
 

--- a/Rlog/View/WorkSpace/WorkSpaceDetailView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceDetailView.swift
@@ -56,18 +56,23 @@ struct WorkSpaceDetailView: View {
                 .padding(.bottom, -8)
                 
                 StrokeButton(label: "+ 근무패턴 추가", buttonType: .add) {
+                    viewModel.isCreateScheduleModalShow.toggle()
                 }
                 .padding(.bottom, -8)
                 
                 HDivider()
                 
                 StrokeButton(label: "근무지 삭제", buttonType: .destructive) {
+                    viewModel.isAlertOpen.toggle()
                 }
                 .alert("근무지 삭제", isPresented: $viewModel.isAlertOpen) {
                     Button("취소", role: .cancel) {
+                        viewModel.isAlertOpen.toggle()
                     }
                     Button("삭제", role: .destructive) {
-                        
+                        viewModel.didTapDeleteButton {
+                            dismiss()
+                        }
                     }
                 } message: {
                     Text("해당 근무지를 삭제합니다.?")
@@ -102,6 +107,9 @@ struct WorkSpaceDetailView: View {
                 }
             }
         }
+        .sheet(isPresented: $viewModel.isCreateScheduleModalShow) {
+            Text("근무 패턴 생성")
+        }
         .background(Color.backgroundWhite)
         .navigationBarBackButtonHidden()
         .onAppear {
@@ -125,35 +133,6 @@ private extension WorkSpaceDetailView {
                 }
             })
         }
-    }
-    
-    @ViewBuilder
-    func schedulesContainer() -> some View {
-        HStack(spacing: 0) {
-            HStack(spacing: 0) {
-                //                ForEach(schedule.repeatedSchedule, id:\.self) { weekDay in
-                //                    Text(weekDay)
-                //                        .font(.body)
-                //                        .foregroundColor(.fontBlack)
-                //                        .padding(.horizontal, 1)
-                //                }
-            }
-            .padding(.trailing, 3)
-            Spacer()
-            Text("11 : 00 - 12 : 00")
-                .font(.body)
-                .foregroundColor(.fontBlack)
-            Button {
-            } label: {
-                Image(systemName: "minus.circle")
-                    .foregroundColor(.red)
-                    .padding(.leading, 16)
-            }
-        }
-        .padding()
-        .frame(minWidth: 0, maxWidth: .infinity, maxHeight: 54)
-        .background(Color.backgroundWhite)
-        .cornerRadius(10)
     }
 }
 

--- a/Rlog/View/WorkSpace/WorkSpaceDetailView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceDetailView.swift
@@ -27,8 +27,8 @@ struct WorkSpaceDetailView: View {
     @Environment(\.dismiss) var dismiss
     @ObservedObject var viewModel: WorkSpaceDetailViewModel
     
-    init() {
-        viewModel = WorkSpaceDetailViewModel()
+    init(workspace: WorkspaceEntity) {
+        viewModel = WorkSpaceDetailViewModel(workspace: workspace)
     }
     
     var body: some View {
@@ -44,15 +44,15 @@ struct WorkSpaceDetailView: View {
                     .foregroundColor(.grayMedium)
                     .padding(.bottom, -16)
                 
-                //                ForEach(viewModel.schedules) { schedule in
-                ScheduleContainer(
-                    repeatedSchedule: ["월 화 수 목"],
-                    startHour: "10",
-                    startMinute: "00",
-                    endHour: "12",
-                    endMinute: "00"
-                )
-                //                }
+                ForEach(viewModel.schedules, id: \.self) { schedule in
+                    ScheduleContainer(
+                        repeatedSchedule: schedule.repeatDays,
+                        startHour: String(schedule.startHour),
+                        startMinute: String(schedule.startMinute),
+                        endHour: String(schedule.endHour),
+                        endMinute: String(schedule.endMinute)
+                    )
+                }
                 .padding(.bottom, -8)
                 
                 StrokeButton(label: "+ 근무패턴 추가", buttonType: .add) {
@@ -92,6 +92,9 @@ struct WorkSpaceDetailView: View {
             }
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button(action: {
+                    viewModel.didTapConfirmButton {
+                        dismiss()
+                    }
                 }){
                     Text("완료")
                         .fontWeight(.bold)
@@ -101,6 +104,9 @@ struct WorkSpaceDetailView: View {
         }
         .background(Color.backgroundWhite)
         .navigationBarBackButtonHidden()
+        .onAppear {
+            viewModel.onAppear()
+        }
     }
 }
 

--- a/Rlog/View/WorkSpace/WorkSpaceDetailView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceDetailView.swift
@@ -57,6 +57,17 @@ struct WorkSpaceDetailView: View {
                 }
                 .padding(.bottom, -8)
                 
+                ForEach(viewModel.shouldCreateSchdeules, id: \.self) { schedule in
+                    ScheduleContainer(
+                        repeatedSchedule: schedule.repeatedSchedule,
+                        startHour: schedule.startHour,
+                        startMinute: schedule.startMinute,
+                        endHour: schedule.endHour,
+                        endMinute: schedule.endMinute
+                    )
+                }
+                .padding(.bottom, -8)
+                
                 StrokeButton(label: "+ 근무패턴 추가", buttonType: .add) {
                     viewModel.isCreateScheduleModalShow.toggle()
                 }
@@ -84,7 +95,7 @@ struct WorkSpaceDetailView: View {
                     .padding(.top, -8)
                     Spacer()
                 }
-                Spacer()
+//                Spacer()
             }
             .padding(EdgeInsets(top: 24, leading: 16, bottom: 0, trailing: 16))
         }
@@ -115,8 +126,7 @@ struct WorkSpaceDetailView: View {
         .sheet(isPresented: $viewModel.isCreateScheduleModalShow, onDismiss: {
             print("1")
         }) {
-            Text("WorkSpaceCreateCreatingScheduleView")
-//            WorkSpaceCreateCreatingScheduleView(isShowingModal: $viewModel.isCreateScheduleModalShow, scheduleList: $viewModel.schedules)
+            WorkSpaceCreateCreatingScheduleView(isShowingModal: $viewModel.isCreateScheduleModalShow, scheduleList: $viewModel.shouldCreateSchdeules)
         }
         .background(Color.backgroundWhite)
         .navigationBarBackButtonHidden()

--- a/Rlog/View/WorkSpace/WorkSpaceDetailView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceDetailView.swift
@@ -62,23 +62,26 @@ struct WorkSpaceDetailView: View {
                 
                 HDivider()
                 
-                StrokeButton(label: "근무지 삭제", buttonType: .destructive) {
-                    viewModel.isAlertOpen.toggle()
-                }
-                .alert("근무지 삭제", isPresented: $viewModel.isAlertOpen) {
-                    Button("취소", role: .cancel) {
+                HStack {
+                    Spacer()
+                    StrokeButton(label: "근무지 삭제", buttonType: .destructive) {
                         viewModel.isAlertOpen.toggle()
                     }
-                    Button("삭제", role: .destructive) {
-                        viewModel.didTapDeleteButton {
-                            dismiss()
+                    .alert("근무지 삭제", isPresented: $viewModel.isAlertOpen) {
+                        Button("취소", role: .cancel) {
+                            viewModel.isAlertOpen.toggle()
                         }
+                        Button("삭제", role: .destructive) {
+                            viewModel.didTapDeleteButton {
+                                dismiss()
+                            }
+                        }
+                    } message: {
+                        Text("해당 근무지를 삭제합니다.?")
                     }
-                } message: {
-                    Text("해당 근무지를 삭제합니다.?")
+                    .padding(.top, -8)
+                    Spacer()
                 }
-                .padding(.top, -8)
-                
                 Spacer()
             }
             .padding(EdgeInsets(top: 24, leading: 16, bottom: 0, trailing: 16))

--- a/Rlog/View/WorkSpace/WorkSpaceListView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceListView.swift
@@ -62,8 +62,5 @@ struct WorkSpaceListView: View {
             .background(Color.backgroundWhite)
         }
         .accentColor(.fontBlack)
-        .onAppear {
-            viewModel.onAppear()
-        }
     }
 }

--- a/Rlog/View/WorkSpace/WorkSpaceListView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceListView.swift
@@ -60,6 +60,9 @@ struct WorkSpaceListView: View {
                 }
             }
             .background(Color.backgroundWhite)
+            .onAppear {
+                viewModel.onAppear()
+            }
         }
         .accentColor(.fontBlack)
     }

--- a/Rlog/View/WorkSpace/WorkSpaceListView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceListView.swift
@@ -34,8 +34,8 @@ struct WorkSpaceListView: View {
         NavigationView {
             
             ScrollView {
-                ForEach(models, id: \.self) { model in
-                    WorkSpaceCell(model: model)
+                ForEach(viewModel.workspaces, id: \.self) { workspace in
+                    WorkSpaceCell(workspace: workspace)
                 }
                 Text("")
             }
@@ -62,81 +62,8 @@ struct WorkSpaceListView: View {
             .background(Color.backgroundWhite)
         }
         .accentColor(.fontBlack)
-    }
-}
-
-struct CustomModel: Hashable {
-    
-    let name: String
-    let hourlyWage: Int
-    let date: String
-    let hasJuhyu: Bool
-    let hasTax: Bool
-    let color: String
-    let workDays: String
-    let schedules: String
-    let paymentDay: Int
-    
-    // TODO: CoreData model에도 추가해야함.
-    func getValue(info: WorkSpaceInfo) -> String {
-        switch info {
-        case .hourlyWage: return "\(hourlyWage)"
-        case .paymentDay: return date
-        case .hasJuhyu:
-            return hasJuhyu ? "적용" : "미적용"
-        case .hasTax:
-            return hasTax ? "적용" : "미적용"
-        case .workDays: return "\(workDays + " " + schedules)"
+        .onAppear {
+            viewModel.onAppear()
         }
     }
 }
-
-// TODO: Data 주입 후, 삭제 해야함
-let models = [
-    CustomModel(
-        name: "팍이네 팍팍 감자탕",
-        hourlyWage: 2000,
-        date: "2022.07.11",
-        hasJuhyu: true,
-        hasTax: false,
-        color: "PointRed",
-        workDays : "월, 화, 수, 목요일",
-        schedules : "10:00 - 12:00",
-        paymentDay:10
-    ),
-    CustomModel(
-        name: "팍이네 팍팍팍 감자탕",
-        hourlyWage: 2000,
-        date: "2022.07.11",
-        hasJuhyu: false,
-        hasTax: true,
-        color: "PointPink",
-        workDays : "월, 화, 수, 목요일",
-        schedules : "10:00 - 12:00",
-        paymentDay:10
-    ),
-    CustomModel(
-        name: "팍이네 팍팍팍팍 감자탕",
-        hourlyWage: 2000,
-        date: "2022.07.11",
-        hasJuhyu: true,
-        hasTax: false,
-        color: "PointYellow",
-        workDays : "월, 화, 수, 목요일",
-        schedules : "10:00 - 12:00",
-        paymentDay:10
-    ),
-    CustomModel(
-        name: "팍이네 팍팍팍팍 감자탕",
-        hourlyWage: 2000,
-        date: "2022.07.11",
-        hasJuhyu: true,
-        hasTax: false,
-        color: "PointYellow",
-        workDays : "월, 화, 수, 목요일",
-        schedules : "10:00 - 12:00",
-        paymentDay:10
-    )
-]
-
-

--- a/Rlog/ViewModel/MonthlyCalculate/MonthlyCalculateListViewModel.swift
+++ b/Rlog/ViewModel/MonthlyCalculate/MonthlyCalculateListViewModel.swift
@@ -12,7 +12,7 @@ final class MonthlyCalculateListViewModel: ObservableObject {
     @Published var date = Date()
     @Published var workspaces: [WorkspaceEntity] = []
     
-    func onAppear() {
+    init() {
         getAllWorkspaces()
     }
 }

--- a/Rlog/ViewModel/MonthlyCalculate/MonthlyCalculateListViewModel.swift
+++ b/Rlog/ViewModel/MonthlyCalculate/MonthlyCalculateListViewModel.swift
@@ -5,9 +5,20 @@
 //  Created by Kim Insub on 2022/11/10.
 //
 
-import Foundation
+import SwiftUI
 
 @MainActor
 final class MonthlyCalculateListViewModel: ObservableObject {
     @Published var date = Date()
+    @Published var workspaces: [WorkspaceEntity] = []
+}
+
+private extension MonthlyCalculateListViewModel {
+    func getAllWorkspaces() {
+        let result = CoreDataManager.shared.getAllWorkspaces()
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.workspaces = result
+        }
+    }
 }

--- a/Rlog/ViewModel/MonthlyCalculate/MonthlyCalculateListViewModel.swift
+++ b/Rlog/ViewModel/MonthlyCalculate/MonthlyCalculateListViewModel.swift
@@ -20,9 +20,6 @@ final class MonthlyCalculateListViewModel: ObservableObject {
 private extension MonthlyCalculateListViewModel {
     func getAllWorkspaces() {
         let result = CoreDataManager.shared.getAllWorkspaces()
-        DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
-            self.workspaces = result
-        }
+        workspaces = result
     }
 }

--- a/Rlog/ViewModel/MonthlyCalculate/MonthlyCalculateListViewModel.swift
+++ b/Rlog/ViewModel/MonthlyCalculate/MonthlyCalculateListViewModel.swift
@@ -11,6 +11,10 @@ import SwiftUI
 final class MonthlyCalculateListViewModel: ObservableObject {
     @Published var date = Date()
     @Published var workspaces: [WorkspaceEntity] = []
+    
+    func onAppear() {
+        getAllWorkspaces()
+    }
 }
 
 private extension MonthlyCalculateListViewModel {

--- a/Rlog/ViewModel/MonthlyCalculate/MonthlyCalculateListViewModel.swift
+++ b/Rlog/ViewModel/MonthlyCalculate/MonthlyCalculateListViewModel.swift
@@ -12,7 +12,7 @@ final class MonthlyCalculateListViewModel: ObservableObject {
     @Published var date = Date()
     @Published var workspaces: [WorkspaceEntity] = []
     
-    init() {
+    func onAppear() {
         getAllWorkspaces()
     }
 }

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceCellViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceCellViewModel.swift
@@ -22,9 +22,6 @@ final class WorkSpaceCellViewModel: ObservableObject {
 private extension WorkSpaceCellViewModel {
     func getAllSchedules() {
         let result = CoreDataManager.shared.getSchedules(of: workspace)
-        DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
-            self.schedules = result
-        }
+        self.schedules = result
     }
 }

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceCellViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceCellViewModel.swift
@@ -5,10 +5,26 @@
 //  Created by Kim Insub on 2022/10/26.
 //
 
-import Combine
 import Foundation
 
 @MainActor
 final class WorkSpaceCellViewModel: ObservableObject {
-   
+    var workspace: WorkspaceEntity
+    
+    @Published var schedules: [ScheduleEntity] = []
+    
+    init(workspace: WorkspaceEntity) {
+        self.workspace = workspace
+        getAllSchedules()
+    }
+}
+
+private extension WorkSpaceCellViewModel {
+    func getAllSchedules() {
+        let result = CoreDataManager.shared.getSchedules(of: workspace)
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.schedules = result
+        }
+    }
 }

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceCreateConfirmationViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceCreateConfirmationViewModel.swift
@@ -51,17 +51,26 @@ private extension WorkSpaceCreateConfirmationViewModel {
     }
     
     func createWorkspaceAndSchedule() async {
-        // TODO: - workspace create test용
-        let workspaceEntity = CoreDataManager.shared.createWorkspace(
+        Task {
+            let workspace = await createWorkSpace()
+            await createSchedules(workspace: workspace)
+        }
+    }
+    
+    func createWorkSpace() async -> WorkspaceEntity {
+        return CoreDataManager.shared.createWorkspace(
             name: workspaceData.name,
             payDay: Int16(workspaceData.paymentDay) ?? 0,
             hourlyWage: Int32(workspaceData.hourlyWage) ?? 0,
             hasTax: workspaceData.hasTax,
             hasJuhyu: workspaceData.hasJuhyu
         )
+    }
+    
+    func createSchedules(workspace: WorkspaceEntity) async {
         for schedule in scheduleData  {
             CoreDataManager.shared.createSchedule(
-                of: workspaceEntity,
+                of: workspace,
                 repeatDays: schedule.repeatedSchedule,
                 startHour: Int16(schedule.startHour) ?? 0,
                 startMinute: Int16(schedule.startMinute) ?? 0,

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceCreateConfirmationViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceCreateConfirmationViewModel.swift
@@ -25,7 +25,7 @@ final class WorkSpaceCreateConfirmationViewModel: ObservableObject {
     
     func didTapConfirmButton() {
         Task {
-            await createWorkSpace()
+            await createWorkspaceAndSchedule()
             popToRoot()
         }
     }
@@ -50,15 +50,25 @@ private extension WorkSpaceCreateConfirmationViewModel {
         return (timeInterval / 3600)
     }
     
-    func createWorkSpace() async {
+    func createWorkspaceAndSchedule() async {
         // TODO: - workspace create test용
-        CoreDataManager.shared.createWorkspace(
-            name: "GS25 포항공대점",
-            payDay: Int16(10),
-            hourlyWage: Int32(9160),
-            hasTax: false,
-            hasJuhyu: false
+        let workspaceEntity = CoreDataManager.shared.createWorkspace(
+            name: workspaceData.name,
+            payDay: Int16(workspaceData.paymentDay) ?? 0,
+            hourlyWage: Int32(workspaceData.hourlyWage) ?? 0,
+            hasTax: workspaceData.hasTax,
+            hasJuhyu: workspaceData.hasJuhyu
         )
+        for schedule in scheduleData  {
+            CoreDataManager.shared.createSchedule(
+                of: workspaceEntity,
+                repeatDays: schedule.repeatedSchedule,
+                startHour: Int16(schedule.startHour) ?? 0,
+                startMinute: Int16(schedule.startMinute) ?? 0,
+                endHour: Int16(schedule.endHour) ?? 0,
+                endMinute: Int16(schedule.endMinute) ?? 0
+            )
+        }
     }
 }
 

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceCreateConfirmationViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceCreateConfirmationViewModel.swift
@@ -24,7 +24,10 @@ final class WorkSpaceCreateConfirmationViewModel: ObservableObject {
     private let hasJuhyu = false
     
     func didTapConfirmButton() {
-        popToRoot()
+        Task {
+            await createWorkSpace()
+            popToRoot()
+        }
     }
 }
 
@@ -45,6 +48,17 @@ private extension WorkSpaceCreateConfirmationViewModel {
         let timeInterval = endDate.timeIntervalSinceReferenceDate - startDate.timeIntervalSinceReferenceDate
         
         return (timeInterval / 3600)
+    }
+    
+    func createWorkSpace() async {
+        // TODO: - workspace create test용
+        CoreDataManager.shared.createWorkspace(
+            name: "GS25 포항공대점",
+            payDay: Int16(10),
+            hourlyWage: Int32(9160),
+            hasTax: false,
+            hasJuhyu: false
+        )
     }
 }
 

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceCreateScheduleListViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceCreateScheduleListViewModel.swift
@@ -46,7 +46,6 @@ private extension WorkSpaceCreateScheduleListViewModel {
 }
 
 struct ScheduleModel: Hashable{
-    var scheduleEntity: ScheduleEntity?
     var repeatedSchedule: [String] = []
     var startHour: String = ""
     var startMinute: String = ""

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceCreateScheduleListViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceCreateScheduleListViewModel.swift
@@ -46,6 +46,7 @@ private extension WorkSpaceCreateScheduleListViewModel {
 }
 
 struct ScheduleModel: Hashable{
+    var scheduleEntity: ScheduleEntity?
     var repeatedSchedule: [String] = []
     var startHour: String = ""
     var startMinute: String = ""

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceDetailViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceDetailViewModel.swift
@@ -18,6 +18,7 @@ final class WorkSpaceDetailViewModel: ObservableObject {
     @Published var hasTax: Bool
     @Published var hasJuhyu: Bool
     @Published var isAlertOpen = false
+    @Published var isCreateScheduleModalShow = false
     @Published var schedules: [ScheduleEntity] = []
     
     init(workspace: WorkspaceEntity) {
@@ -32,6 +33,13 @@ final class WorkSpaceDetailViewModel: ObservableObject {
     func didTapConfirmButton(completion: @escaping (() -> Void)) {
         Task {
             await updateWorkspace()
+            completion()
+        }
+    }
+    
+    func didTapDeleteButton(completion: @escaping (() -> Void)) {
+        Task {
+            await deleteWorkspace()
             completion()
         }
     }
@@ -51,6 +59,10 @@ private extension WorkSpaceDetailViewModel {
             hasTax: hasTax,
             hasJuhyu: hasJuhyu
         )
+    }
+    
+    func deleteWorkspace() async {
+        CoreDataManager.shared.deleteWorkspace(workspace: workspace)
     }
     
     func getAllSchedules() {

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceDetailViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceDetailViewModel.swift
@@ -90,19 +90,16 @@ private extension WorkSpaceDetailViewModel {
     
     func getAllSchedules() {
         let result = CoreDataManager.shared.getSchedules(of: workspace)
-        DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
-            self.schedules = []
-            for schedule in result {
-                self.schedules.append(ScheduleModel(
-                    scheduleEntity: schedule,
-                    repeatedSchedule: schedule.repeatDays,
-                    startHour: String(schedule.startHour),
-                    startMinute: String(schedule.startMinute),
-                    endHour: String(schedule.endHour),
-                    endMinute: String(schedule.endMinute)
-                ))
-            }
+        schedules = []
+        for schedule in result {
+            schedules.append(ScheduleModel(
+                scheduleEntity: schedule,
+                repeatedSchedule: schedule.repeatDays,
+                startHour: String(schedule.startHour),
+                startMinute: String(schedule.startMinute),
+                endHour: String(schedule.endHour),
+                endMinute: String(schedule.endMinute)
+            ))
         }
     }
 }

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceDetailViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceDetailViewModel.swift
@@ -63,6 +63,7 @@ private extension WorkSpaceDetailViewModel {
         CoreDataManager.shared.deleteWorkspace(workspace: workspace)
     }
     
+    // MARK: - 현재는 스케줄 추가만 가능하지만, 스케줄 수정에 대한 확장 가능성이 있으므로, 함수를 이렇게 설정
     func updateSchedules() async {
         for schedule in schedules {
             if let scheduleEntity = schedule.scheduleEntity {
@@ -91,6 +92,7 @@ private extension WorkSpaceDetailViewModel {
         let result = CoreDataManager.shared.getSchedules(of: workspace)
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
+            self.schedules = []
             for schedule in result {
                 self.schedules.append(ScheduleModel(
                     scheduleEntity: schedule,

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceDetailViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceDetailViewModel.swift
@@ -21,6 +21,7 @@ final class WorkSpaceDetailViewModel: ObservableObject {
     @Published var isAlertOpen = false
     @Published var isCreateScheduleModalShow = false
     @Published var schedules: [ScheduleEntity] = []
+    @Published var shouldCreateSchdeules: [ScheduleModel] = []
     
     init(workspace: WorkspaceEntity) {
         self.workspace = workspace
@@ -35,7 +36,8 @@ final class WorkSpaceDetailViewModel: ObservableObject {
     func didTapConfirmButton(completion: @escaping (() -> Void)) {
         Task {
             await updateWorkspace()
-            await updateSchedules()
+            await deleteSchedules()
+            await createSchedules()
             completion()
         }
     }
@@ -71,9 +73,22 @@ private extension WorkSpaceDetailViewModel {
         CoreDataManager.shared.deleteWorkspace(workspace: workspace)
     }
     
-    func updateSchedules() async {
+    func deleteSchedules() async {
         for schedule in deleteSchedules {
             CoreDataManager.shared.deleteSchedule(of: schedule)
+        }
+    }
+    
+    func createSchedules() async {
+        for schedule in shouldCreateSchdeules {
+            CoreDataManager.shared.createSchedule(
+                of: workspace,
+                repeatDays: schedule.repeatedSchedule,
+                startHour: Int16(schedule.startHour) ?? 12,
+                startMinute: Int16(schedule.startMinute) ?? 0,
+                endHour: Int16(schedule.endHour) ?? 14,
+                endMinute: Int16(schedule.endMinute) ?? 0
+            )
         }
     }
     

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceDetailViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceDetailViewModel.swift
@@ -21,7 +21,7 @@ final class WorkSpaceDetailViewModel: ObservableObject {
     @Published var isAlertOpen = false
     @Published var isCreateScheduleModalShow = false
     @Published var schedules: [ScheduleEntity] = []
-    @Published var shouldCreateSchdeules: [ScheduleModel] = []
+    @Published var shouldCreateSchedules: [ScheduleModel] = []
     
     init(workspace: WorkspaceEntity) {
         self.workspace = workspace
@@ -55,6 +55,12 @@ final class WorkSpaceDetailViewModel: ObservableObject {
             schedules.remove(at: index)
         }
     }
+    
+    func didTapDeleteScheduleModelButton(schedule: ScheduleModel) {
+        if let index = shouldCreateSchedules.firstIndex(of: schedule) {
+            shouldCreateSchedules.remove(at: index)
+        }
+    }
 }
 
 private extension WorkSpaceDetailViewModel {
@@ -80,7 +86,7 @@ private extension WorkSpaceDetailViewModel {
     }
     
     func createSchedules() async {
-        for schedule in shouldCreateSchdeules {
+        for schedule in shouldCreateSchedules {
             CoreDataManager.shared.createSchedule(
                 of: workspace,
                 repeatDays: schedule.repeatedSchedule,

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceDetailViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceDetailViewModel.swift
@@ -11,7 +11,6 @@ import Foundation
 @MainActor
 final class WorkSpaceDetailViewModel: ObservableObject {
     var workspace: WorkspaceEntity
-    var deleteSchedules: [ScheduleEntity] = []
     
     @Published var name: String
     @Published var hourlyWageString: String
@@ -20,6 +19,10 @@ final class WorkSpaceDetailViewModel: ObservableObject {
     @Published var hasJuhyu: Bool
     @Published var isAlertOpen = false
     @Published var isCreateScheduleModalShow = false
+    
+    // TODO: - 리팩토링이 필요한 부분으로 생각됨
+    // https://fdsa0106.atlassian.net/browse/BD-197?atlOrigin=eyJpIjoiZTBjMjczNGMzZmI1NDJmNmFmNmVlOTQ0NjhkOTI2ZGYiLCJwIjoiaiJ9
+    var deleteSchedules: [ScheduleEntity] = []
     @Published var schedules: [ScheduleEntity] = []
     @Published var shouldCreateSchedules: [ScheduleModel] = []
     

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceDetailViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceDetailViewModel.swift
@@ -10,11 +10,54 @@ import Foundation
 
 @MainActor
 final class WorkSpaceDetailViewModel: ObservableObject {
-    @Published var name = ""
-    @Published var hourlyWageString = ""
-    @Published var paymentDayString = ""
-    @Published var hasTax = true
-    @Published var hasJuhyu = true
+    var workspace: WorkspaceEntity
+    
+    @Published var name: String
+    @Published var hourlyWageString: String
+    @Published var paymentDayString: String
+    @Published var hasTax: Bool
+    @Published var hasJuhyu: Bool
     @Published var isAlertOpen = false
+    @Published var schedules: [ScheduleEntity] = []
+    
+    init(workspace: WorkspaceEntity) {
+        self.workspace = workspace
+        self.name = workspace.name
+        self.hourlyWageString = String(workspace.hourlyWage)
+        self.paymentDayString = String(workspace.payDay)
+        self.hasTax = workspace.hasTax
+        self.hasJuhyu = workspace.hasJuhyu
+    }
+    
+    func didTapConfirmButton(completion: @escaping (() -> Void)) {
+        Task {
+            await updateWorkspace()
+            completion()
+        }
+    }
+    
+    func onAppear() {
+        getAllSchedules()
+    }
 }
 
+private extension WorkSpaceDetailViewModel {
+    func updateWorkspace() async {
+        CoreDataManager.shared.editWorkspace(
+            workspace: workspace,
+            name: name,
+            payDay: Int16(paymentDayString) ?? 1,
+            hourlyWage: Int32(hourlyWageString) ?? 10000,
+            hasTax: hasTax,
+            hasJuhyu: hasJuhyu
+        )
+    }
+    
+    func getAllSchedules() {
+        let result = CoreDataManager.shared.getSchedules(of: workspace)
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.schedules = result
+        }
+    }
+}

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceDetailViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceDetailViewModel.swift
@@ -11,6 +11,7 @@ import Foundation
 @MainActor
 final class WorkSpaceDetailViewModel: ObservableObject {
     var workspace: WorkspaceEntity
+    var schedulesDummy: [ScheduleModel] = []
     
     @Published var name: String
     @Published var hourlyWageString: String
@@ -18,7 +19,15 @@ final class WorkSpaceDetailViewModel: ObservableObject {
     @Published var hasTax: Bool
     @Published var hasJuhyu: Bool
     @Published var isAlertOpen = false
-    @Published var isCreateScheduleModalShow = false
+    @Published var isCreateScheduleModalShow = false {
+        didSet {
+            Task {
+                print("2")
+                await createSchedule()
+                getAllSchedules()
+            }
+        }
+    }
     @Published var schedules: [ScheduleEntity] = []
     
     init(workspace: WorkspaceEntity) {
@@ -63,6 +72,10 @@ private extension WorkSpaceDetailViewModel {
     
     func deleteWorkspace() async {
         CoreDataManager.shared.deleteWorkspace(workspace: workspace)
+    }
+    
+    func createSchedule() async {
+        print(schedulesDummy)
     }
     
     func getAllSchedules() {

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceListViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceListViewModel.swift
@@ -13,7 +13,7 @@ final class WorkSpaceListViewModel: ObservableObject {
     @Published var isShowingSheet = false
     @Published var workspaces: [WorkspaceEntity] = []
     
-    init() {
+    func onAppear() {
         getAllWorkspaces()
     }
 }

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceListViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceListViewModel.swift
@@ -10,14 +10,10 @@ import Foundation
 
 @MainActor
 final class WorkSpaceListViewModel: ObservableObject {
-    @Published var isShowingSheet = false {
-        didSet {
-            getAllWorkspaces()
-        }
-    }
+    @Published var isShowingSheet = false
     @Published var workspaces: [WorkspaceEntity] = []
     
-    func onAppear() {
+    init() {
         getAllWorkspaces()
     }
 }

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceListViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceListViewModel.swift
@@ -21,9 +21,6 @@ final class WorkSpaceListViewModel: ObservableObject {
 private extension WorkSpaceListViewModel {
     func getAllWorkspaces() {
         let result = CoreDataManager.shared.getAllWorkspaces()
-        DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
-            self.workspaces = result
-        }
+        workspaces = result
     }
 }

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceListViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceListViewModel.swift
@@ -11,5 +11,19 @@ import Foundation
 @MainActor
 final class WorkSpaceListViewModel: ObservableObject {
     @Published var isShowingSheet = false
-  
+    @Published var workspaces: [WorkspaceEntity] = []
+    
+    func onAppear() {
+        getAllWorkspaces()
+    }
+}
+
+private extension WorkSpaceListViewModel {
+    func getAllWorkspaces() {
+        let result = CoreDataManager.shared.getAllWorkspaces()
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.workspaces = result
+        }
+    }
 }

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceListViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceListViewModel.swift
@@ -10,7 +10,11 @@ import Foundation
 
 @MainActor
 final class WorkSpaceListViewModel: ObservableObject {
-    @Published var isShowingSheet = false
+    @Published var isShowingSheet = false {
+        didSet {
+            getAllWorkspaces()
+        }
+    }
     @Published var workspaces: [WorkspaceEntity] = []
     
     func onAppear() {


### PR DESCRIPTION
# 프로젝트 이미지 
(수정 및 구현 사항에 대한 간략한 캡쳐)

<div>
<img src=https://user-images.githubusercontent.com/103025692/202477113-17f68dbd-55f4-4d4c-b0ff-7c4603666b67.png width=250 />

<img src=https://user-images.githubusercontent.com/103025692/202477131-74f723b5-faff-4fa9-a0d8-200cd5da47cf.png width=250 />

<img src=https://user-images.githubusercontent.com/103025692/202477143-8eab8abe-bd5c-4bad-9a32-a8593c695770.png width=250 />
</div>

## 세부 사항
(여기에 수정 사항에 대한 자세한 내용을 작성해 주세요.)
- CoreData 내 WorkspaceEntity와 ScheduleEntity의 CRUD 테스트입니다.
- 근무지 생성, 근무지 정보 수정, 근무지 삭제, 스케줄 생성, 스케줄 삭제 기능 동작 확인했습니다.
- 태스크를 잘못나눠 PR이 커진 점 죄송합니다...

## 기타 질문 및 특이 사항
(궁금한 사항들, 하면서 느낀 점 및 공유할 내용)
- 뷰 연결 및 뷰모델 작성까지 진행했습니다.
- 근무지를 수정하는 화면에서, CoreData 내의 근무지 내용을 수정하는 로직은 완료를 눌렀을 경우에만 실행이 되어야 합니다. 
- 스케줄을 추가하거나 삭제하더라도 완료를 누르기 전까지 CoreData 내부는 변경되지 않도록 하고, 근무지 생성 플로우에서 스케줄을 만드는 View를 재활용하기 위해,
- 현재로서는 근무지 수정 뷰에서 deleteSchedules, schedules, shouldCreateSchedules 3개로 관리하고 있습니다. 추후 리팩토링이 필요할 것 같습니다.
- [관련 이슈 지라 링크](https://fdsa0106.atlassian.net/browse/BD-197?atlOrigin=eyJpIjoiZTBjMjczNGMzZmI1NDJmNmFmNmVlOTQ0NjhkOTI2ZGYiLCJwIjoiaiJ9)
- WorkSpaceDetailView의 뷰 쪼개기가 필요할 것 같습니다! @Junghoon-P 
 
## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)
- [x]  필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x]  코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x]  제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x]  본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
