### PR TITLE
Bd 199 core data manager 초기 설정 workday 관리 로직 추가

### DIFF
--- a/Rlog/CoreData/CoreDataManager.swift
+++ b/Rlog/CoreData/CoreDataManager.swift
@@ -157,6 +157,13 @@ extension CoreDataManager {
         workday.schedule = schedule
         save()
     }
+    
+    func getAllWorkdays(of workspace: WorkspaceEntity) -> [WorkdayEntity] {
+        let fetchRequest: NSFetchRequest<WorkdayEntity> = WorkdayEntity.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "workspace.name == %@", workspace.name)
+        let result = try? context.fetch(fetchRequest)
+        return result ?? []
+    }
 
     func getWorkdaysBetween(start: Date, target: Date) -> [WorkdayEntity] {
         let fetchRequest: NSFetchRequest<WorkdayEntity> = WorkdayEntity.fetchRequest()

--- a/Rlog/CoreData/CoreDataManager.swift
+++ b/Rlog/CoreData/CoreDataManager.swift
@@ -93,7 +93,7 @@ extension CoreDataManager {
         startMinute: Int16,
         endHour: Int16,
         endMinute: Int16
-    ) {
+    ) -> ScheduleEntity {
         let schedule = ScheduleEntity(context: context)
         schedule.workspace = workspace
         schedule.repeatDays = repeatDays
@@ -102,6 +102,7 @@ extension CoreDataManager {
         schedule.endHour = endHour
         schedule.endMinute = endMinute
         save()
+        return schedule
     }
 
     func getSchedules(of workspace: WorkspaceEntity) -> [ScheduleEntity] {

--- a/Rlog/Extension/Date+.swift
+++ b/Rlog/Extension/Date+.swift
@@ -8,6 +8,15 @@
 import Foundation
 
 extension Date {
+    var onlyDate: Date? {
+        get {
+            let calender = Calendar.current
+            var dateComponents = calender.dateComponents([.year, .month, .day], from: self)
+            dateComponents.timeZone = NSTimeZone.system
+            return calender.date(from: dateComponents)
+        }
+    }
+    
     // TODO: - DateFormatter+ 구현 후 삭제
     func fetchYearAndMonth() -> String {
         let dateFormatter = DateFormatter()

--- a/Rlog/View/MainTabView.swift
+++ b/Rlog/View/MainTabView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct MainTabView: View {
+    @ObservedObject private var viewModel = MainTabViewModel()
     @StateObject var viewRouter: ViewRouter
     
     var body: some View {
@@ -23,6 +24,11 @@ struct MainTabView: View {
             tabBarView
         }
         .ignoresSafeArea(.keyboard)
+        .onAppear {
+            Task {
+                await viewModel.updateAllSchedules()
+            }
+        }
     }
 }
 

--- a/Rlog/View/MainTabView.swift
+++ b/Rlog/View/MainTabView.swift
@@ -25,9 +25,7 @@ struct MainTabView: View {
         }
         .ignoresSafeArea(.keyboard)
         .onAppear {
-            Task {
-                await viewModel.updateAllSchedules()
-            }
+            viewModel.onAppear()
         }
     }
 }

--- a/Rlog/View/MonthlyCalculate/MonthlyCalculateListView.swift
+++ b/Rlog/View/MonthlyCalculate/MonthlyCalculateListView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct MonthlyCalculateListView: View {
-    @ObservedObject private var viewModel = MonthlyCalculateListViewModel()
+    @StateObject private var viewModel = MonthlyCalculateListViewModel()
     
     var body: some View {
         NavigationView {

--- a/Rlog/View/WorkSpace/WorkSpaceListView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceListView.swift
@@ -27,7 +27,7 @@ enum WorkSpaceInfo: CaseIterable {
 
 
 struct WorkSpaceListView: View {
-    @ObservedObject var viewModel = WorkSpaceListViewModel()
+    @StateObject private var viewModel = WorkSpaceListViewModel()
     
     var body: some View {
         

--- a/Rlog/ViewModel/MainTabViewModel.swift
+++ b/Rlog/ViewModel/MainTabViewModel.swift
@@ -12,44 +12,49 @@ final class MainTabViewModel: ObservableObject {
     func updateAllSchedules() async {
         let workspaces = CoreDataManager.shared.getAllWorkspaces()
         
-        var schedules: [ScheduleEntity] = []
         for workspace in workspaces {
-            schedules.append(contentsOf: CoreDataManager.shared.getSchedules(of: workspace))
-        }
-        
-        for schedule in schedules {
-            await updateWorkdays(workspace: schedule.workspace, schedule: schedule)
-        }
-    }
-    
-    func updateWorkdays(workspace: WorkspaceEntity, schedule: ScheduleEntity) async {
-        guard let after4month = Calendar.current.date(byAdding: DateComponents(month: 4), to: Date()) else { return }
-        
-        // TODO: - 마지막 날짜 가져오기
-        let lastDateOfWorkdays = Date()
-        
-        if lastDateOfWorkdays < after4month {
-            guard var range = Calendar.current.date(byAdding: DateComponents(day: 1), to: lastDateOfWorkdays) else { return }
-            guard let lastAfter1Month = Calendar.current.date(byAdding: DateComponents(month: 1), to: lastDateOfWorkdays) else { return }
-            while range < lastAfter1Month {
-                if schedule.repeatDays.contains(range.fetchDayOfWeek(date: range)) {
-                    guard let startTime = Calendar.current.date(bySettingHour: Int(schedule.startHour), minute: Int(schedule.startMinute), second: 0, of: range) else { return }
-                    guard let endTime = Calendar.current.date(bySettingHour: Int(schedule.endHour), minute: Int(schedule.endMinute), second: 0, of: range) else { return }
-                    
-                    CoreDataManager.shared.createWorkday(
-                        of: workspace,
-                        hourlyWage: workspace.hourlyWage,
-                        hasDone: false,
-                        date: range,
-                        startTime: startTime,
-                        endTime: endTime,
-                        memo: nil,
-                        schedule: schedule
-                    )
-                }
+            let workdays = CoreDataManager.shared.getAllWorkdays(of: workspace)
+            let schedules = CoreDataManager.shared.getSchedules(of: workspace)
+            
+            for schedule in schedules {
+                let workdaysOfSchedule = workdays.filter { $0.schedule == schedule }
                 
-                guard let next = Calendar.current.date(byAdding: DateComponents(day: 1), to: range) else { return }
-                range = next
+                // MARK: - Testing
+                guard let testDate = Calendar.current.date(byAdding: DateComponents(month: 1), to: Date()) else { return }
+                
+//                guard let after4monthOfCurrent = Calendar.current.date(byAdding: DateComponents(month: 4), to: Date()) else { return }
+                guard let after4monthOfCurrent = Calendar.current.date(byAdding: DateComponents(month: 4), to: testDate) else { return }
+                guard var latestWorkday = workdaysOfSchedule.last else { return }
+                print("DEBUG: - TestDate : \(after4monthOfCurrent)")
+                print("DEBUG: - LatestDate : \(latestWorkday.date)")
+                
+                if latestWorkday.date < after4monthOfCurrent {
+                    guard var range = Calendar.current.date(byAdding: DateComponents(day: 1), to: latestWorkday.date) else { return }
+                    guard let after1MonthOfLatestDate = Calendar.current.date(byAdding: DateComponents(month: 1), to: latestWorkday.date) else { return }
+                    
+                    while range < after1MonthOfLatestDate {
+                        if schedule.repeatDays.contains(range.fetchDayOfWeek(date: range)) {
+                            print(range)
+                            
+//                            guard let startTime = Calendar.current.date(bySettingHour: Int(schedule.startHour), minute: Int(schedule.startMinute), second: 0, of: range) else { return }
+//                            guard let endTime = Calendar.current.date(bySettingHour: Int(schedule.endHour), minute: Int(schedule.endMinute), second: 0, of: range) else { return }
+//
+//                            CoreDataManager.shared.createWorkday(
+//                                of: workspace,
+//                                hourlyWage: workspace.hourlyWage,
+//                                hasDone: false,
+//                                date: range,
+//                                startTime: startTime,
+//                                endTime: endTime,
+//                                memo: nil,
+//                                schedule: schedule
+//                            )
+                        }
+                        
+                        guard let next = Calendar.current.date(byAdding: DateComponents(day: 1), to: range) else { return }
+                        range = next
+                    }
+                }
             }
         }
     }

--- a/Rlog/ViewModel/MainTabViewModel.swift
+++ b/Rlog/ViewModel/MainTabViewModel.swift
@@ -9,6 +9,14 @@ import SwiftUI
 
 @MainActor
 final class MainTabViewModel: ObservableObject {
+    func onAppear() {
+        Task {
+            await updateAllSchedules()
+        }
+    }
+}
+
+private extension MainTabViewModel {
     func updateAllSchedules() async {
         let workspaces = CoreDataManager.shared.getAllWorkspaces()
         

--- a/Rlog/ViewModel/MainTabViewModel.swift
+++ b/Rlog/ViewModel/MainTabViewModel.swift
@@ -13,29 +13,34 @@ final class MainTabViewModel: ObservableObject {
         let workspaces = CoreDataManager.shared.getAllWorkspaces()
         
         for workspace in workspaces {
+            // workspace에 연결된 모든 schedule과 workday들을 가져옵니다.
             let workdays = CoreDataManager.shared.getAllWorkdays(of: workspace)
             let schedules = CoreDataManager.shared.getSchedules(of: workspace)
             
             for schedule in schedules {
+                // 모든 schedule에 대해 해당 스케줄에 연결된 Workday를 가져옵니다. - CoreDataManager에 schedule에 연결된 Workday들을 가져오는 함수가 있으면 더 편할 것 같습니다.
                 let workdaysOfSchedule = workdays.filter { $0.schedule == schedule }
                 
-                guard let after4monthOfCurrent = Calendar.current.date(byAdding: DateComponents(month: 4), to: Date()) else { return }
-                guard let latestWorkday = workdaysOfSchedule.last else { return }
+                // 현재로부터 4개월 후와, 마지막 날의 Workday를 가져옵니다.
+                guard let after4monthOfCurrent = Calendar.current.date(byAdding: DateComponents(month: 4), to: Date()),
+                      let latestWorkday = workdaysOfSchedule.last else { return }
                 
+                // 4개월 후의 날짜가 마지막 날의 날짜보다 클 경우에, 추가로 1달치를 생성합니다.
                 if latestWorkday.date < after4monthOfCurrent {
-                    guard var range = Calendar.current.date(byAdding: DateComponents(day: 1), to: latestWorkday.date) else { return }
-                    guard let after1MonthOfLatestDate = Calendar.current.date(byAdding: DateComponents(month: 1), to: latestWorkday.date) else { return }
+                    guard var range = Calendar.current.date(byAdding: DateComponents(day: 1), to: latestWorkday.date),
+                          let after1MonthOfLatestDate = Calendar.current.date(byAdding: DateComponents(month: 1), to: latestWorkday.date) else { return }
                     
                     while range < after1MonthOfLatestDate {
                         if schedule.repeatDays.contains(range.fetchDayOfWeek(date: range)) {
-                            guard let startTime = Calendar.current.date(bySettingHour: Int(schedule.startHour), minute: Int(schedule.startMinute), second: 0, of: range) else { return }
-                            guard let endTime = Calendar.current.date(bySettingHour: Int(schedule.endHour), minute: Int(schedule.endMinute), second: 0, of: range) else { return }
+                            guard let startTime = Calendar.current.date(bySettingHour: Int(schedule.startHour), minute: Int(schedule.startMinute), second: 0, of: range),
+                                  let endTime = Calendar.current.date(bySettingHour: Int(schedule.endHour), minute: Int(schedule.endMinute), second: 0, of: range),
+                                  let date = range.onlyDate else { return }
 
                             CoreDataManager.shared.createWorkday(
                                 of: workspace,
                                 hourlyWage: workspace.hourlyWage,
                                 hasDone: false,
-                                date: range,
+                                date: date,
                                 startTime: startTime,
                                 endTime: endTime,
                                 memo: nil,

--- a/Rlog/ViewModel/MainTabViewModel.swift
+++ b/Rlog/ViewModel/MainTabViewModel.swift
@@ -9,5 +9,48 @@ import SwiftUI
 
 @MainActor
 final class MainTabViewModel: ObservableObject {
-
+    func updateAllSchedules() async {
+        let workspaces = CoreDataManager.shared.getAllWorkspaces()
+        
+        var schedules: [ScheduleEntity] = []
+        for workspace in workspaces {
+            schedules.append(contentsOf: CoreDataManager.shared.getSchedules(of: workspace))
+        }
+        
+        for schedule in schedules {
+            await updateWorkdays(workspace: schedule.workspace, schedule: schedule)
+        }
+    }
+    
+    func updateWorkdays(workspace: WorkspaceEntity, schedule: ScheduleEntity) async {
+        guard let after4month = Calendar.current.date(byAdding: DateComponents(month: 4), to: Date()) else { return }
+        
+        // TODO: - 마지막 날짜 가져오기
+        let lastDateOfWorkdays = Date()
+        
+        if lastDateOfWorkdays < after4month {
+            guard var range = Calendar.current.date(byAdding: DateComponents(day: 1), to: lastDateOfWorkdays) else { return }
+            guard let lastAfter1Month = Calendar.current.date(byAdding: DateComponents(month: 1), to: lastDateOfWorkdays) else { return }
+            while range < lastAfter1Month {
+                if schedule.repeatDays.contains(range.fetchDayOfWeek(date: range)) {
+                    guard let startTime = Calendar.current.date(bySettingHour: Int(schedule.startHour), minute: Int(schedule.startMinute), second: 0, of: range) else { return }
+                    guard let endTime = Calendar.current.date(bySettingHour: Int(schedule.endHour), minute: Int(schedule.endMinute), second: 0, of: range) else { return }
+                    
+                    CoreDataManager.shared.createWorkday(
+                        of: workspace,
+                        hourlyWage: workspace.hourlyWage,
+                        hasDone: false,
+                        date: range,
+                        startTime: startTime,
+                        endTime: endTime,
+                        memo: nil,
+                        schedule: schedule
+                    )
+                }
+                
+                guard let next = Calendar.current.date(byAdding: DateComponents(day: 1), to: range) else { return }
+                range = next
+            }
+        }
+    }
 }

--- a/Rlog/ViewModel/MainTabViewModel.swift
+++ b/Rlog/ViewModel/MainTabViewModel.swift
@@ -19,14 +19,8 @@ final class MainTabViewModel: ObservableObject {
             for schedule in schedules {
                 let workdaysOfSchedule = workdays.filter { $0.schedule == schedule }
                 
-                // MARK: - Testing
-                guard let testDate = Calendar.current.date(byAdding: DateComponents(month: 1), to: Date()) else { return }
-                
-//                guard let after4monthOfCurrent = Calendar.current.date(byAdding: DateComponents(month: 4), to: Date()) else { return }
-                guard let after4monthOfCurrent = Calendar.current.date(byAdding: DateComponents(month: 4), to: testDate) else { return }
+                guard let after4monthOfCurrent = Calendar.current.date(byAdding: DateComponents(month: 4), to: Date()) else { return }
                 guard var latestWorkday = workdaysOfSchedule.last else { return }
-                print("DEBUG: - TestDate : \(after4monthOfCurrent)")
-                print("DEBUG: - LatestDate : \(latestWorkday.date)")
                 
                 if latestWorkday.date < after4monthOfCurrent {
                     guard var range = Calendar.current.date(byAdding: DateComponents(day: 1), to: latestWorkday.date) else { return }
@@ -34,21 +28,19 @@ final class MainTabViewModel: ObservableObject {
                     
                     while range < after1MonthOfLatestDate {
                         if schedule.repeatDays.contains(range.fetchDayOfWeek(date: range)) {
-                            print(range)
-                            
-//                            guard let startTime = Calendar.current.date(bySettingHour: Int(schedule.startHour), minute: Int(schedule.startMinute), second: 0, of: range) else { return }
-//                            guard let endTime = Calendar.current.date(bySettingHour: Int(schedule.endHour), minute: Int(schedule.endMinute), second: 0, of: range) else { return }
-//
-//                            CoreDataManager.shared.createWorkday(
-//                                of: workspace,
-//                                hourlyWage: workspace.hourlyWage,
-//                                hasDone: false,
-//                                date: range,
-//                                startTime: startTime,
-//                                endTime: endTime,
-//                                memo: nil,
-//                                schedule: schedule
-//                            )
+                            guard let startTime = Calendar.current.date(bySettingHour: Int(schedule.startHour), minute: Int(schedule.startMinute), second: 0, of: range) else { return }
+                            guard let endTime = Calendar.current.date(bySettingHour: Int(schedule.endHour), minute: Int(schedule.endMinute), second: 0, of: range) else { return }
+
+                            CoreDataManager.shared.createWorkday(
+                                of: workspace,
+                                hourlyWage: workspace.hourlyWage,
+                                hasDone: false,
+                                date: range,
+                                startTime: startTime,
+                                endTime: endTime,
+                                memo: nil,
+                                schedule: schedule
+                            )
                         }
                         
                         guard let next = Calendar.current.date(byAdding: DateComponents(day: 1), to: range) else { return }

--- a/Rlog/ViewModel/MainTabViewModel.swift
+++ b/Rlog/ViewModel/MainTabViewModel.swift
@@ -20,7 +20,7 @@ final class MainTabViewModel: ObservableObject {
                 let workdaysOfSchedule = workdays.filter { $0.schedule == schedule }
                 
                 guard let after4monthOfCurrent = Calendar.current.date(byAdding: DateComponents(month: 4), to: Date()) else { return }
-                guard var latestWorkday = workdaysOfSchedule.last else { return }
+                guard let latestWorkday = workdaysOfSchedule.last else { return }
                 
                 if latestWorkday.date < after4monthOfCurrent {
                     guard var range = Calendar.current.date(byAdding: DateComponents(day: 1), to: latestWorkday.date) else { return }

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceCreateConfirmationViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceCreateConfirmationViewModel.swift
@@ -93,14 +93,15 @@ private extension WorkSpaceCreateConfirmationViewModel {
         
         while range < after5Month {
             if schedule.repeatDays.contains(range.fetchDayOfWeek(date: range)) {
-                guard let startTime = Calendar.current.date(bySettingHour: Int(schedule.startHour), minute: Int(schedule.startMinute), second: 0, of: range) else { return }
-                guard let endTime = Calendar.current.date(bySettingHour: Int(schedule.endHour), minute: Int(schedule.endMinute), second: 0, of: range) else { return }
+                guard let startTime = Calendar.current.date(bySettingHour: Int(schedule.startHour), minute: Int(schedule.startMinute), second: 0, of: range),
+                      let endTime = Calendar.current.date(bySettingHour: Int(schedule.endHour), minute: Int(schedule.endMinute), second: 0, of: range),
+                      let date = range.onlyDate else { return }
                 
                 CoreDataManager.shared.createWorkday(
                     of: workspace,
                     hourlyWage: workspace.hourlyWage,
                     hasDone: false,
-                    date: range,
+                    date: date,
                     startTime: startTime,
                     endTime: endTime,
                     memo: nil,

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceCreateConfirmationViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceCreateConfirmationViewModel.swift
@@ -53,7 +53,10 @@ private extension WorkSpaceCreateConfirmationViewModel {
     func createWorkspaceAndSchedule() async {
         Task {
             let workspace = await createWorkSpace()
-            await createSchedules(workspace: workspace)
+            let schedules = await createSchedules(workspace: workspace)
+            for schedule in schedules {
+                await createInitWorkdays(workspace: workspace, schedule: schedule)
+            }
         }
     }
     
@@ -67,16 +70,46 @@ private extension WorkSpaceCreateConfirmationViewModel {
         )
     }
     
-    func createSchedules(workspace: WorkspaceEntity) async {
+    func createSchedules(workspace: WorkspaceEntity) async -> [ScheduleEntity] {
+        var schedules: [ScheduleEntity] = []
         for schedule in scheduleData  {
-            CoreDataManager.shared.createSchedule(
-                of: workspace,
-                repeatDays: schedule.repeatedSchedule,
-                startHour: Int16(schedule.startHour) ?? 0,
-                startMinute: Int16(schedule.startMinute) ?? 0,
-                endHour: Int16(schedule.endHour) ?? 0,
-                endMinute: Int16(schedule.endMinute) ?? 0
+            schedules.append(
+                CoreDataManager.shared.createSchedule(
+                    of: workspace,
+                    repeatDays: schedule.repeatedSchedule,
+                    startHour: Int16(schedule.startHour) ?? 0,
+                    startMinute: Int16(schedule.startMinute) ?? 0,
+                    endHour: Int16(schedule.endHour) ?? 0,
+                    endMinute: Int16(schedule.endMinute) ?? 0
+                )
             )
+        }
+        return schedules
+    }
+    
+    func createInitWorkdays(workspace: WorkspaceEntity, schedule: ScheduleEntity) async {
+        var range = Date()
+        guard let after5Month = Calendar.current.date(byAdding: DateComponents(month: 5), to: range) else { return }
+        
+        while range < after5Month {
+            if schedule.repeatDays.contains(range.fetchDayOfWeek(date: range)) {
+                guard let startTime = Calendar.current.date(bySettingHour: Int(schedule.startHour), minute: Int(schedule.startMinute), second: 0, of: range) else { return }
+                guard let endTime = Calendar.current.date(bySettingHour: Int(schedule.endHour), minute: Int(schedule.endMinute), second: 0, of: range) else { return }
+                
+                CoreDataManager.shared.createWorkday(
+                    of: workspace,
+                    hourlyWage: workspace.hourlyWage,
+                    hasDone: false,
+                    date: range,
+                    startTime: startTime,
+                    endTime: endTime,
+                    memo: nil,
+                    schedule: schedule
+                )
+            }
+            
+            guard let next = Calendar.current.date(byAdding: DateComponents(day: 1), to: range) else { return }
+            range = next
         }
     }
 }

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceDetailViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceDetailViewModel.swift
@@ -114,14 +114,15 @@ private extension WorkSpaceDetailViewModel {
         
         while range < after5Month {
             if schedule.repeatDays.contains(range.fetchDayOfWeek(date: range)) {
-                guard let startTime = Calendar.current.date(bySettingHour: Int(schedule.startHour), minute: Int(schedule.startMinute), second: 0, of: range) else { return }
-                guard let endTime = Calendar.current.date(bySettingHour: Int(schedule.endHour), minute: Int(schedule.endMinute), second: 0, of: range) else { return }
+                guard let startTime = Calendar.current.date(bySettingHour: Int(schedule.startHour), minute: Int(schedule.startMinute), second: 0, of: range),
+                      let endTime = Calendar.current.date(bySettingHour: Int(schedule.endHour), minute: Int(schedule.endMinute), second: 0, of: range),
+                      let date = range.onlyDate else { return }
                 
                 CoreDataManager.shared.createWorkday(
                     of: workspace,
                     hourlyWage: workspace.hourlyWage,
                     hasDone: false,
-                    date: range,
+                    date: date,
                     startTime: startTime,
                     endTime: endTime,
                     memo: nil,

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceDetailViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceDetailViewModel.swift
@@ -40,7 +40,10 @@ final class WorkSpaceDetailViewModel: ObservableObject {
         Task {
             await updateWorkspace()
             await deleteSchedules()
-            await createSchedules()
+            let schedules = await createSchedules()
+            for schedule in schedules {
+                await createInitWorkdays(worspace: workspace, schedule: schedule)
+            }
             completion()
         }
     }
@@ -88,16 +91,46 @@ private extension WorkSpaceDetailViewModel {
         }
     }
     
-    func createSchedules() async {
+    func createSchedules() async -> [ScheduleEntity] {
+        var createdSchedules: [ScheduleEntity] = []
         for schedule in shouldCreateSchedules {
-            CoreDataManager.shared.createSchedule(
-                of: workspace,
-                repeatDays: schedule.repeatedSchedule,
-                startHour: Int16(schedule.startHour) ?? 12,
-                startMinute: Int16(schedule.startMinute) ?? 0,
-                endHour: Int16(schedule.endHour) ?? 14,
-                endMinute: Int16(schedule.endMinute) ?? 0
+            createdSchedules.append(
+                CoreDataManager.shared.createSchedule(
+                    of: workspace,
+                    repeatDays: schedule.repeatedSchedule,
+                    startHour: Int16(schedule.startHour) ?? 12,
+                    startMinute: Int16(schedule.startMinute) ?? 0,
+                    endHour: Int16(schedule.endHour) ?? 14,
+                    endMinute: Int16(schedule.endMinute) ?? 0
+                )
             )
+        }
+        return createdSchedules
+    }
+    
+    func createInitWorkdays(worspace: WorkspaceEntity, schedule: ScheduleEntity) async {
+        var range = Date()
+        guard let after5Month = Calendar.current.date(byAdding: DateComponents(month: 5), to: range) else { return }
+        
+        while range < after5Month {
+            if schedule.repeatDays.contains(range.fetchDayOfWeek(date: range)) {
+                guard let startTime = Calendar.current.date(bySettingHour: Int(schedule.startHour), minute: Int(schedule.startMinute), second: 0, of: range) else { return }
+                guard let endTime = Calendar.current.date(bySettingHour: Int(schedule.endHour), minute: Int(schedule.endMinute), second: 0, of: range) else { return }
+                
+                CoreDataManager.shared.createWorkday(
+                    of: workspace,
+                    hourlyWage: workspace.hourlyWage,
+                    hasDone: false,
+                    date: range,
+                    startTime: startTime,
+                    endTime: endTime,
+                    memo: nil,
+                    schedule: schedule
+                )
+            }
+            
+            guard let next = Calendar.current.date(byAdding: DateComponents(day: 1), to: range) else { return }
+            range = next
         }
     }
     


### PR DESCRIPTION
# 프로젝트 이미지 
(수정 및 구현 사항에 대한 간략한 캡쳐)

근무지 생성 시, 수목 스케줄에 대한 생성 내역
<div>
<img src=https://user-images.githubusercontent.com/103025692/202902386-8f052083-74cd-4507-a8fb-927dbefc5254.png width=275 />
<img src=https://user-images.githubusercontent.com/103025692/202902380-f9551a61-1dd0-4a5a-a1e1-ef790794cb4c.png width=275 />
</div>

메인 탭에서 테스트 날짜가 현재부터 1달 뒤 일 경우, 4달 후의 날짜와 가장 먼 Workday의 날짜를 비교해서 1달 치를 생성하는 내역
<div>
<img src=https://user-images.githubusercontent.com/103025692/202910305-60acbe2c-2ca1-4e32-9962-6e18052ccff3.png width=275 />
<img src=https://user-images.githubusercontent.com/103025692/202910170-da9df915-b2d2-4250-b1d1-88de39cbd115.png width=275 />
</div>

## 세부 사항
(여기에 수정 사항에 대한 자세한 내용을 작성해 주세요.)
- 근무지, 정산 리스트에서 ObservedObject를 StateObject로 바꿨습니다!
- 근무지 생성 시 스케줄의 초기 Workday들을 생성하는 로직 구현
- 근무지 수정에서 새 스케줄 생성할 경우에 초기 Workday들을 생성하는 로직 구현
- MainTabView의 onAppear가 호출될 경우, 4개월 이상의 Workday가 남아있는지 확인 후, 아닐 경우에 생성하는 로직 구현
- 스케줄에 해당하는 Workday들을 생성해주기 위해, CoreDataManager 내의 createSchedule이 Schedule을 리턴하도록 변경했습니다.
- 한 스케줄에 대해 5개월 치를 생성했을 때 실 기기에서 메모리 부하는 없는 것 같습니다(27mb -> 30mb).

## 기타 질문 및 특이 사항
(궁금한 사항들, 하면서 느낀 점 및 공유할 내용)
- 일단 모든 Workspace에 대해 모든 Workday들을 가져와 해당 스케줄인 것만 가져와서 처리하는 로직을 사용하고 있습니다.
- CoreData에서 Schedule을 비교해서 가져올 방법을 모르겠습니다(workspace처럼 name이 없으니?)
- 스케줄 생성 시, 날짜 순으로 생성하고 있고, 사용자가 추가할 WorkdayEntity의 경우에는 ScheduleEntity 값을 가지지 않기 때문에, Workday를 가져와서 날짜 순으로 정리할 필요가 없다고 생각했습니다 = 필요하면 넣어야 합니다,
- 스케줄 삭제 시, 미래 스케줄 삭제를 위해 CoreDataManager에 오늘 날짜 이후의 스케줄에 해당하는 Workday들을 리턴하는 함수가 필요합니다. 
`getWorkdaysOfSchedules(schedule: ScheduleEntity) -> [오늘 이후의 Workday]`
- 4개월 치가 남아있는지 확인하기 위해, 스케줄 중 가장 미래에 있는 Workday를 리턴하는 함수가 필요합니다.
`getLastWorkdayOfSchedule(schedule: ScheduleEntity) -> 가장 미래의 Workday`
 
## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)
- [x]  필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x]  코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x]  제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x]  본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
