### PR TITLE
BD-211 ScheduleListViewModel 의 로직명을 개선합니다.

### DIFF
--- a/Rlog/View/Schedule/ScheduleListView.swift
+++ b/Rlog/View/Schedule/ScheduleListView.swift
@@ -179,7 +179,7 @@ private extension ScheduleListView {
                         .frame(maxWidth: .infinity)
                         .padding(.top, 5)
                         
-                        if viewModel.verifyScheduleDate(currentWeek[index]) {
+                        if viewModel.getWorkdayIndicator(currentWeek[index]) {
                             Circle()
                                 .frame(width: 6, height: 6)
                                 .foregroundColor(

--- a/Rlog/View/Schedule/ScheduleListView.swift
+++ b/Rlog/View/Schedule/ScheduleListView.swift
@@ -19,11 +19,11 @@ struct ScheduleListView: View {
         return viewModel.getWeekdayOfDate(viewModel.currentDate)
     }
     
-    var allWorkdays: (upcoming: [WorkdayEntity], expired: [WorkdayEntity]) {
+    var allWorkdays: (hasNotDone: [WorkdayEntity], hasDone: [WorkdayEntity]) {
         return viewModel.workdays
     }
     
-    var workdays: (upcoming: [WorkdayEntity], expired: [WorkdayEntity]) {
+    var workdays: (hasNotDone: [WorkdayEntity], hasDone: [WorkdayEntity]) {
         return viewModel.schedulesOfFocusDate
     }
     
@@ -249,7 +249,7 @@ private extension ScheduleListView {
     
     @ViewBuilder
     var scheduleList: some View {
-        if workdays.upcoming.isEmpty && workdays.expired.isEmpty {
+        if workdays.hasNotDone.isEmpty && workdays.hasDone.isEmpty {
             scheduleNotFound
         } else {
             ScrollView(showsIndicators: false) {
@@ -257,7 +257,7 @@ private extension ScheduleListView {
                     Text("예정된 일정")
                         .font(Font.callout.bold())
                         .padding(.bottom, 12)
-                    ForEach(workdays.upcoming) { data in
+                    ForEach(workdays.hasNotDone) { data in
                         NavigationLink(
                             destination: ScheduleUpdateView(workday: data).navigationTitle("근무 일정 수정하기"),
                             isActive: $isScheduleUpdateViewActive
@@ -265,12 +265,12 @@ private extension ScheduleListView {
                             ScheduleCell(currentDate: viewModel.currentDate, data: data)
                         }
                     }
-                    if !workdays.expired.isEmpty {
+                    if !workdays.hasDone.isEmpty {
                         Text("확정된 일정")
                             .font(Font.callout.bold())
                             .padding(.top, 32)
                             .padding(.bottom, 12)
-                        ForEach(workdays.expired) { data in
+                        ForEach(workdays.hasDone) { data in
                             NavigationLink(
                                 destination: ScheduleUpdateView(workday: data).navigationTitle("근무 일정 수정하기"),
                                 isActive: $isScheduleUpdateViewActive

--- a/Rlog/View/Schedule/ScheduleListView.swift
+++ b/Rlog/View/Schedule/ScheduleListView.swift
@@ -108,7 +108,7 @@ private extension ScheduleListView {
         VStack(spacing: 0) {
             Group {
                 if viewModel.workspaces.isEmpty {
-                    workspaceNotFound
+                    emptyWorkspaceView
                 } else {
                     weekDaysContainer
                         .padding(.top)
@@ -160,11 +160,11 @@ private extension ScheduleListView {
     }
     
     var weekdayBox: some View {
-        
+
         HStack(spacing: 0) {
             ForEach(0..<currentWeek.count, id: \.self) { index in
                 ZStack {
-                    
+
                     VStack(spacing: 0) {
                         Button {
                             viewModel.didTapDate(currentWeek[index])
@@ -178,7 +178,7 @@ private extension ScheduleListView {
                         }
                         .frame(maxWidth: .infinity)
                         .padding(.top, 5)
-                        
+
                         if viewModel.getWorkdayIndicator(currentWeek[index]) {
                             Circle()
                                 .frame(width: 6, height: 6)
@@ -186,34 +186,38 @@ private extension ScheduleListView {
                                     viewModel.verifyCurrentMonth(currentWeek[index].month) ? .primary : .gray
                                 )
                         }
-                        
+
                         Spacer()
                     }
-                    
-                    if viewModel.highlightFocusDate(currentWeek[index].day) {
 
-                        VStack(spacing: 0) {
-                            Text("\(currentWeek[index].day)")
-                                .font(.callout)
-                                .foregroundColor(Color.backgroundWhite)
-                                .padding(.bottom, 9)
-                            if viewModel.verifyScheduleDate(currentWeek[index]) {
-                                Circle()
-                                    .frame(width: 6, height: 6)
-                                    .foregroundColor(.white)
-                            } else {
-                                Spacer()
-                            }
-                        }
-                        .padding(EdgeInsets(top: 3, leading: 6, bottom: 7, trailing: 6))
-                        .frame(width: 32)
-                        .background(Color.primary)
-                        .cornerRadius(10)
-                        .padding(.top, 2)
-                        .transition(AnyTransition.opacity.animation(.easeInOut))
-                    }
+                    focusedDate(index)
                 }
             }
+        }
+    }
+    
+    @ViewBuilder
+    func focusedDate(_ index: Int) -> some View {
+        if viewModel.highlightFocusDate(currentWeek[index].day) {
+            VStack(spacing: 0) {
+                Text("\(currentWeek[index].day)")
+                    .font(.callout)
+                    .foregroundColor(Color.backgroundWhite)
+                    .padding(.bottom, 9)
+                if viewModel.getWorkdayIndicator(currentWeek[index]) {
+                    Circle()
+                        .frame(width: 6, height: 6)
+                        .foregroundColor(.white)
+                } else {
+                    Spacer()
+                }
+            }
+            .padding(EdgeInsets(top: 3, leading: 6, bottom: 7, trailing: 6))
+            .frame(width: 32)
+            .background(Color.primary)
+            .cornerRadius(10)
+            .padding(.top, 2)
+            .transition(AnyTransition.opacity.animation(.easeInOut))
         }
     }
     
@@ -250,7 +254,7 @@ private extension ScheduleListView {
     @ViewBuilder
     var scheduleList: some View {
         if workdays.hasNotDone.isEmpty && workdays.hasDone.isEmpty {
-            scheduleNotFound
+            emptyScheduleView
         } else {
             ScrollView(showsIndicators: false) {
                 VStack(alignment: .leading, spacing: 8) {
@@ -284,7 +288,7 @@ private extension ScheduleListView {
         }
     }
     
-    var scheduleNotFound: some View {
+    var emptyScheduleView: some View {
         VStack(spacing: 0) {
             Spacer()
             Image("rlogGreenLogo")
@@ -296,7 +300,7 @@ private extension ScheduleListView {
         }
     }
     
-    var workspaceNotFound: some View {
+    var emptyWorkspaceView: some View {
         VStack(spacing: 0) {
             Spacer()
             Text("근무지탭에서 근무지를 등록해주세요.")

--- a/Rlog/View/Schedule/ScheduleListView.swift
+++ b/Rlog/View/Schedule/ScheduleListView.swift
@@ -19,12 +19,8 @@ struct ScheduleListView: View {
         return viewModel.getWeekdayOfDate(viewModel.currentDate)
     }
     
-    var allWorkdays: (hasNotDone: [WorkdayEntity], hasDone: [WorkdayEntity]) {
-        return viewModel.workdays
-    }
-    
-    var workdays: (hasNotDone: [WorkdayEntity], hasDone: [WorkdayEntity]) {
-        return viewModel.schedulesOfFocusedDate
+    var workdaysOfFocusedDate: (hasNotDone: [WorkdayEntity], hasDone: [WorkdayEntity]) {
+        return viewModel.workdaysOfFocusedDate
     }
     
     var currentMonth: String {
@@ -253,7 +249,7 @@ private extension ScheduleListView {
     
     @ViewBuilder
     var scheduleList: some View {
-        if workdays.hasNotDone.isEmpty && workdays.hasDone.isEmpty {
+        if workdaysOfFocusedDate.hasNotDone.isEmpty && workdaysOfFocusedDate.hasDone.isEmpty {
             emptyScheduleView
         } else {
             ScrollView(showsIndicators: false) {
@@ -261,7 +257,7 @@ private extension ScheduleListView {
                     Text("예정된 일정")
                         .font(Font.callout.bold())
                         .padding(.bottom, 12)
-                    ForEach(workdays.hasNotDone) { data in
+                    ForEach(workdaysOfFocusedDate.hasNotDone) { data in
                         NavigationLink(
                             destination: ScheduleUpdateView(workday: data).navigationTitle("근무 일정 수정하기"),
                             isActive: $isScheduleUpdateViewActive
@@ -269,12 +265,12 @@ private extension ScheduleListView {
                             ScheduleCell(currentDate: viewModel.currentDate, data: data)
                         }
                     }
-                    if !workdays.hasDone.isEmpty {
+                    if !workdaysOfFocusedDate.hasDone.isEmpty {
                         Text("확정된 일정")
                             .font(Font.callout.bold())
                             .padding(.top, 32)
                             .padding(.bottom, 12)
-                        ForEach(workdays.hasDone) { data in
+                        ForEach(workdaysOfFocusedDate.hasDone) { data in
                             NavigationLink(
                                 destination: ScheduleUpdateView(workday: data).navigationTitle("근무 일정 수정하기"),
                                 isActive: $isScheduleUpdateViewActive

--- a/Rlog/View/Schedule/ScheduleListView.swift
+++ b/Rlog/View/Schedule/ScheduleListView.swift
@@ -24,7 +24,7 @@ struct ScheduleListView: View {
     }
     
     var workdays: (hasNotDone: [WorkdayEntity], hasDone: [WorkdayEntity]) {
-        return viewModel.schedulesOfFocusDate
+        return viewModel.schedulesOfFocusedDate
     }
     
     var currentMonth: String {

--- a/Rlog/ViewModel/Schedule/ScheduleListViewModel.swift
+++ b/Rlog/ViewModel/Schedule/ScheduleListViewModel.swift
@@ -12,7 +12,7 @@ final class ScheduleListViewModel: ObservableObject {
     let timeManager = TimeManager()
     @Published var workspaces: [WorkspaceEntity] = []
     @Published var workdays: (hasNotDone: [WorkdayEntity], hasDone: [WorkdayEntity]) = ([], [])
-    @Published var schedulesOfFocusDate: (hasNotDone: [WorkdayEntity], hasDone: [WorkdayEntity]) = ([], [])
+    @Published var schedulesOfFocusedDate: (hasNotDone: [WorkdayEntity], hasDone: [WorkdayEntity]) = ([], [])
     @Published var nextDate = Calendar.current.date(byAdding: .weekOfMonth, value: 1, to: Date()) ?? Date()
     @Published var previousDate = Calendar.current.date(byAdding: .weekOfMonth, value: -1, to: Date()) ?? Date()
     @Published var currentDate = Date() {
@@ -204,15 +204,15 @@ extension ScheduleListViewModel {
     // 🔥 네이밍 추천 받습니다.
     // 사용자가 터치한 날짜의 근무 일정이 있을 경우 화면에 표시합니다.
     func getWorkdaysOfFocusDate() {
-        schedulesOfFocusDate.hasNotDone.removeAll()
-        schedulesOfFocusDate.hasDone.removeAll()
+        schedulesOfFocusedDate.hasNotDone.removeAll()
+        schedulesOfFocusedDate.hasDone.removeAll()
         
         for data in workdays.0 {
             if data.date.onlyDate == currentDate.onlyDate {
                 if data.hasDone {
-                    schedulesOfFocusDate.hasDone.append(data)
+                    schedulesOfFocusedDate.hasDone.append(data)
                 } else {
-                    schedulesOfFocusDate.hasNotDone.append(data)
+                    schedulesOfFocusedDate.hasNotDone.append(data)
                 }
             }
         }

--- a/Rlog/ViewModel/Schedule/ScheduleListViewModel.swift
+++ b/Rlog/ViewModel/Schedule/ScheduleListViewModel.swift
@@ -12,7 +12,7 @@ final class ScheduleListViewModel: ObservableObject {
     let timeManager = TimeManager()
     @Published var workspaces: [WorkspaceEntity] = []
     @Published var workdays: (hasNotDone: [WorkdayEntity], hasDone: [WorkdayEntity]) = ([], [])
-    @Published var schedulesOfFocusedDate: (hasNotDone: [WorkdayEntity], hasDone: [WorkdayEntity]) = ([], [])
+    @Published var workdaysOfFocusedDate: (hasNotDone: [WorkdayEntity], hasDone: [WorkdayEntity]) = ([], [])
     @Published var nextDate = Calendar.current.date(byAdding: .weekOfMonth, value: 1, to: Date()) ?? Date()
     @Published var previousDate = Calendar.current.date(byAdding: .weekOfMonth, value: -1, to: Date()) ?? Date()
     @Published var currentDate = Date() {
@@ -204,15 +204,15 @@ extension ScheduleListViewModel {
     // 🔥 네이밍 추천 받습니다.
     // 사용자가 터치한 날짜의 근무 일정이 있을 경우 화면에 표시합니다.
     func getWorkdaysOfFocusDate() {
-        schedulesOfFocusedDate.hasNotDone.removeAll()
-        schedulesOfFocusedDate.hasDone.removeAll()
+        workdaysOfFocusedDate.hasNotDone.removeAll()
+        workdaysOfFocusedDate.hasDone.removeAll()
         
         for data in workdays.0 {
             if data.date.onlyDate == currentDate.onlyDate {
                 if data.hasDone {
-                    schedulesOfFocusedDate.hasDone.append(data)
+                    workdaysOfFocusedDate.hasDone.append(data)
                 } else {
-                    schedulesOfFocusedDate.hasNotDone.append(data)
+                    workdaysOfFocusedDate.hasNotDone.append(data)
                 }
             }
         }

--- a/Rlog/ViewModel/Schedule/ScheduleListViewModel.swift
+++ b/Rlog/ViewModel/Schedule/ScheduleListViewModel.swift
@@ -31,7 +31,7 @@ final class ScheduleListViewModel: ObservableObject {
         // 생성된 근무지 여부를 확인합니다. 생성된 근무지가 없다면 예외처리 화면을 표시합니다.
         getAllWorkspaces()
         getWorkdaysOfFiveMonths()
-        getSchedulesOfFocusDate()
+        getWorkdaysOfFocusDate()
     }
     
     func didScrollToNextWeek() {
@@ -52,7 +52,7 @@ final class ScheduleListViewModel: ObservableObject {
     
     func didTapDate(_ date: CalendarModel) {
         changeFocusDate(date)
-        getSchedulesOfFocusDate()
+        getWorkdaysOfFocusDate()
     }
 }
 
@@ -203,7 +203,7 @@ extension ScheduleListViewModel {
     
     // 🔥 네이밍 추천 받습니다.
     // 사용자가 터치한 날짜의 근무 일정이 있을 경우 화면에 표시합니다.
-    func getSchedulesOfFocusDate() {
+    func getWorkdaysOfFocusDate() {
         schedulesOfFocusDate.hasNotDone.removeAll()
         schedulesOfFocusDate.hasDone.removeAll()
         
@@ -218,10 +218,9 @@ extension ScheduleListViewModel {
         }
     }
     
-    // 🔥 네이밍 추천 받습니다.
     // 스크롤 캘린더에 Circle 표시를 하기 위한 함수입니다.
     // 해당 일자에 근무 일정이 있을 경우 Circle을 표시합니다.
-    func verifyScheduleDate(_ date: CalendarModel) -> Bool {
+    func getWorkdayIndicator(_ date: CalendarModel) -> Bool {
         let givenDate = calendar.date(from: DateComponents(year: date.year, month: date.month, day: date.day)) ?? Date()
         
         if !workdays.hasNotDone.isEmpty || !workdays.hasDone.isEmpty {

--- a/Rlog/ViewModel/Schedule/TimeManager.swift
+++ b/Rlog/ViewModel/Schedule/TimeManager.swift
@@ -7,6 +7,14 @@
 
 import Foundation
 
+
+// Sample calendar model
+struct CalendarModel {
+    let year: Int
+    let month: Int
+    let day: Int
+}
+
 final class TimeManager {
     let calendar = Calendar.current
     let formatter = DateFormatter(dateFormatType: .weekday)


### PR DESCRIPTION
# 프로젝트 이미지 

https://user-images.githubusercontent.com/88080251/203251827-49eaabe2-8656-427c-b660-75594f624948.mov



## 세부 사항
- 근무지를 생성한 후 메인 화면에서 일정을 확인합니다.
- 상기 로직에서 기존에 사용하던 코드를 리팩토링 했습니다.

## 기타 질문 및 특이 사항
- 샘플 영상에서 월, 화, 수로 일정을 설정했으나 메인 화면에서 월요일이 표시되지 않는 이유는 아래와 같습니다.
- 시뮬레이터 상 날짜가 11월 22일이고, 로직 상 근무지 생성 날짜로부터 과거의 일정은 불러오지 않습니다.
- 월요일의 경우 11월21일의 과거일이므로 데이터가 존재하지 않습니다.
- 🔥날짜 비교용으로 사용하던 임시 모델인 CalendarModel이 있는데 이를 제거하고자 합니다. 우선은 리뷰 대상에서 제외 부탁 드립니다. 차후 작업 하여 개선하겠습니다.
 
## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)
- [x]  필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x]  코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x]  제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x]  본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
