### PR TITLE
Bd 225 메인 탭 바에 줄 삭제

### DIFF
--- a/Rlog/View/MainTabView.swift
+++ b/Rlog/View/MainTabView.swift
@@ -12,7 +12,7 @@ struct MainTabView: View {
     @StateObject var viewRouter: ViewRouter
     
     var body: some View {
-        VStack {
+        VStack(spacing: 0) {
             switch viewRouter.currentTab {
             case .schedule:
                 Tab.schedule.view


### PR DESCRIPTION
# 프로젝트 이미지 
(수정 및 구현 사항에 대한 간략한 캡쳐)

<img src=https://user-images.githubusercontent.com/103025692/203743497-38fcbdc4-4daa-4830-bf6e-6b3b26ceb4f0.png width=275 />

## 세부 사항
(여기에 수정 사항에 대한 자세한 내용을 작성해 주세요.)
- 메인 탭 바 상단의 하얀 줄을 없앴습니다.

## 기타 질문 및 특이 사항
(궁금한 사항들, 하면서 느낀 점 및 공유할 내용)
- VStack에 Spacing이 있어서 발생하는 문제였습니다.
 
## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)
- [x]  필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x]  코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x]  제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x]  본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
