### PR TITLE
Bd 226 근무 생성 뒤로 가기 버튼 수정

### DIFF
--- a/Rlog/View/WorkSpace/WorkSpaceCreateConfirmationView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceCreateConfirmationView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct WorkSpaceCreateConfirmationView: View {
     @ObservedObject private var viewModel: WorkSpaceCreateConfirmationViewModel
     
+    @Environment(\.dismiss) var dismiss
+    
     init(isActiveNavigation: Binding<Bool>, workspaceData: WorkSpaceModel, scheduleData: [ScheduleModel]) {
         self.viewModel = WorkSpaceCreateConfirmationViewModel(
             isActiveNavigation: isActiveNavigation,
@@ -32,7 +34,12 @@ struct WorkSpaceCreateConfirmationView: View {
             .padding(.horizontal)
         }
         .navigationBarTitle("근무지 등록")
+        .navigationBarBackButtonHidden()
         .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                backButton
+            }
+            
             ToolbarItem(placement: .navigationBarTrailing) {
                 toolbarConfirmButton
             }
@@ -41,6 +48,18 @@ struct WorkSpaceCreateConfirmationView: View {
 }
 
 private extension WorkSpaceCreateConfirmationView {
+    var backButton: some View {
+        Button(action: {
+            dismiss()
+        }, label: {
+            HStack(spacing: 5) {
+                Image(systemName: "chevron.backward")
+                Text("이전")
+            }
+            .foregroundColor(Color.fontBlack)
+        })
+    }
+    
     var WorkTypeInfo: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text("근무 패턴")

--- a/Rlog/View/WorkSpace/WorkSpaceCreateScheduleListView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceCreateScheduleListView.swift
@@ -9,6 +9,9 @@ import SwiftUI
 
 struct WorkSpaceCreateScheduleListView: View {
     @ObservedObject var viewModel: WorkSpaceCreateScheduleListViewModel
+    
+    @Environment(\.dismiss) var dismiss
+    
     init(isActiveNavigation: Binding<Bool>, workspaceModel: WorkSpaceModel) {
         self.viewModel = WorkSpaceCreateScheduleListViewModel(isActiveNavigation: isActiveNavigation, workspaceModel: workspaceModel)
     }
@@ -29,7 +32,12 @@ struct WorkSpaceCreateScheduleListView: View {
         }
         .padding(.horizontal)
         .navigationBarTitle("근무패턴 등록")
+        .navigationBarBackButtonHidden()
         .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                backButton
+            }
+            
             ToolbarItem(placement: .navigationBarTrailing) {
                 toolbarNextButton
             }
@@ -44,6 +52,18 @@ struct WorkSpaceCreateScheduleListView: View {
 }
 
 private extension WorkSpaceCreateScheduleListView {
+    var backButton: some View {
+        Button(action: {
+            dismiss()
+        }, label: {
+            HStack(spacing: 5) {
+                Image(systemName: "chevron.backward")
+                Text("이전")
+            }
+            .foregroundColor(Color.fontBlack)
+        })
+    }
+    
     var toolbarNextButton: some View {
         NavigationLink(destination:  WorkSpaceCreateConfirmationView(
             isActiveNavigation: $viewModel.isActiveNavigation,

--- a/Rlog/View/WorkSpace/WorkSpaceCreateView.swift
+++ b/Rlog/View/WorkSpace/WorkSpaceCreateView.swift
@@ -16,6 +16,8 @@ struct WorkSpaceCreateView: View {
     
     @FocusState var checkoutInFocus: WritingState?
     
+    @Environment(\.dismiss) var dismiss
+    
     var body: some View {
         VStack(alignment: .leading, spacing: 24) {
             guidingText
@@ -42,23 +44,15 @@ struct WorkSpaceCreateView: View {
         .padding(.horizontal)
         .navigationBarTitle("근무지 등록")
         .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden()
         .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                backButton
+            }
+            
             ToolbarItem(placement: .navigationBarTrailing) {
                 if !viewModel.isHiddenToolBarItem {
-                    NavigationLink {
-                        WorkSpaceCreateScheduleListView(
-                            isActiveNavigation: $viewModel.isActiveNavigation, workspaceModel: WorkSpaceModel(
-                                name: viewModel.workSpace,
-                                paymentDay: viewModel.payday,
-                                hourlyWage: viewModel.hourlyWage,
-                                hasTax: viewModel.hasTax,
-                                hasJuhyu: viewModel.hasJuhyu
-                            )
-                        )
-                    } label: {
-                        Text("다음")
-                            .foregroundColor(.primary)
-                    }
+                    nextButton
                 }
             }
         }
@@ -71,6 +65,35 @@ struct WorkSpaceCreateView: View {
 }
 
 private extension WorkSpaceCreateView {
+    var backButton: some View {
+        Button(action: {
+            dismiss()
+        }, label: {
+            HStack(spacing: 5) {
+                Image(systemName: "chevron.backward")
+                Text("이전")
+            }
+            .foregroundColor(Color.fontBlack)
+        })
+    }
+    
+    var nextButton: some View {
+        NavigationLink {
+            WorkSpaceCreateScheduleListView(
+                isActiveNavigation: $viewModel.isActiveNavigation, workspaceModel: WorkSpaceModel(
+                    name: viewModel.workSpace,
+                    paymentDay: viewModel.payday,
+                    hourlyWage: viewModel.hourlyWage,
+                    hasTax: viewModel.hasTax,
+                    hasJuhyu: viewModel.hasJuhyu
+                )
+            )
+        } label: {
+            Text("다음")
+                .foregroundColor(.primary)
+        }
+    }
+    
     // 가이드 텍스트
     var guidingText: some View {
         TitleSubView(title: viewModel.currentState.title)
@@ -130,10 +153,3 @@ private extension WorkSpaceCreateView {
         }
     }
 }
-//
-//extension UINavigationController {
-//    // Remove back button text
-//    open override func viewWillLayoutSubviews() {
-//        navigationBar.topItem?.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
-//    }
-//}


### PR DESCRIPTION
# 프로젝트 이미지 
(수정 및 구현 사항에 대한 간략한 캡쳐)

<div>
<img src=https://user-images.githubusercontent.com/103025692/203763339-4c4a93df-dda5-4c16-a8cf-8cc5d9f2197e.png width=250 />
<img src=https://user-images.githubusercontent.com/103025692/203763353-11bbd88b-b1c3-4ff9-bdbd-f08ecb4e52d5.png width=250 />
<img src=https://user-images.githubusercontent.com/103025692/203763363-2d863c02-29b9-41e3-8846-c9242b337ab9.png width=250 />
</div>

## 세부 사항
(여기에 수정 사항에 대한 자세한 내용을 작성해 주세요.)
- 근무지 생성 과정에서 뒤로가기 버튼을 디자인대로 수정했습니다.

## 기타 질문 및 특이 사항
(궁금한 사항들, 하면서 느낀 점 및 공유할 내용)
- 커스텀으로 넣은 부분이라, 뒤로가기 제스쳐는 먹히지 않습니다. 적용된 뷰에 대해 수정이 필요할까요?
 
## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)
- [x]  필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x]  코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x]  제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x]  본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
