### PR TITLE
BD-234 근무 삭제 시 크래시가 발생하는 에러를 수정합니다.

### DIFF
--- a/Rlog/Manager/WorkTypeManager.swift
+++ b/Rlog/Manager/WorkTypeManager.swift
@@ -11,7 +11,6 @@ final class WorkTypeManager {
     private let timeManager = TimeManager()
 
     func defineWorkType(workday: WorkdayEntity) -> WorkDayType {
-        print("✅✅✅", workday.date)
         let calendar = Calendar.current
         let workspace = workday.workspace
         let schedules = CoreDataManager.shared.getSchedules(of: workspace)

--- a/Rlog/Manager/WorkTypeManager.swift
+++ b/Rlog/Manager/WorkTypeManager.swift
@@ -11,6 +11,7 @@ final class WorkTypeManager {
     private let timeManager = TimeManager()
 
     func defineWorkType(workday: WorkdayEntity) -> WorkDayType {
+        print("✅✅✅", workday.date)
         let calendar = Calendar.current
         let workspace = workday.workspace
         let schedules = CoreDataManager.shared.getSchedules(of: workspace)

--- a/Rlog/View/Schedule/ScheduleCell.swift
+++ b/Rlog/View/Schedule/ScheduleCell.swift
@@ -8,10 +8,10 @@
 import SwiftUI
 
 struct ScheduleCell: View {
-    @StateObject var viewModel: ScheduleCellViewModel
+    @ObservedObject var viewModel: ScheduleCellViewModel
     
     init(of data: WorkdayEntity, didTapConfirm: @escaping () -> Void) {
-        _viewModel = StateObject(wrappedValue: ScheduleCellViewModel(of: data, didTapConfirm: didTapConfirm))
+        self.viewModel = ScheduleCellViewModel(of: data, didTapConfirm: didTapConfirm)
     }
     
     var body: some View {

--- a/Rlog/View/Schedule/ScheduleCell.swift
+++ b/Rlog/View/Schedule/ScheduleCell.swift
@@ -8,16 +8,15 @@
 import SwiftUI
 
 struct ScheduleCell: View {
-    @ObservedObject var viewModel: ScheduleCellViewModel
+    @StateObject var viewModel: ScheduleCellViewModel
     
     init(of data: WorkdayEntity, didTapConfirm: @escaping () -> Void) {
-        self.viewModel = ScheduleCellViewModel(of: data, didTapConfirm: didTapConfirm)
+        _viewModel = StateObject(wrappedValue: ScheduleCellViewModel(of: data, didTapConfirm: didTapConfirm))
     }
     
     var body: some View {
         scheduleInfo
             .transition(AnyTransition.opacity.animation(.easeInOut))
-            .onAppear { viewModel.onAppear() }
     }
 }
 

--- a/Rlog/ViewModel/Schedule/ScheduleCellViewModel.swift
+++ b/Rlog/ViewModel/Schedule/ScheduleCellViewModel.swift
@@ -21,10 +21,6 @@ final class ScheduleCellViewModel: ObservableObject{
     init(of data: WorkdayEntity, didTapConfirm: @escaping () -> Void) {
         self.data = data
         self.didTapConfirm = didTapConfirm
-        onAppear()
-    }
-    
-    func onAppear() {
         self.workType = workTypeManager.defineWorkType(workday: data)
         getSpentHour(data.endTime, data.startTime)
         getStartAndEndTimeAndMinute(data.startTime, data.endTime)


### PR DESCRIPTION
# 프로젝트 이미지 
N/A

## 세부 사항
- 근무 일정 삭제 시 앱이 크래시가 나던 에러를 수정했습니다.
- 크래시 원인을 아래와 같이 추측하고 있습니다.
- 기존 ScheduleCell은 파일 내 onAppear 메소드를 사용하고 있고, 이는 viewModel에서 해당 일정의 근무 정보를 불러오는 역할을 하고 있습니다. 근무 일정을 삭제하게 되면 당연히 해당 일정에 대한 정보도 삭제가 되나 onAppear가 작동하면서 없는 정보를 로드하게 됩니다. 이 때 크래시가 발생했을 것으로 사료됩니다.
- 이에 onAppear 메소드를 삭제하고 viewModel이 initialized 되었을 때에만 일정 정보를 불러오는 것으로 대체하였고, 크래시 에러를 우선적으로 해결했습니다. 

## 기타 질문 및 특이 사항
- N/A
 
## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)
- [x]  필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x]  코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x]  제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x]  본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
