### PR TITLE
Bd 243 근무지 정보 입력 시 예외처리

### DIFF
--- a/Rlog/View/Components/BorderedTextField.swift
+++ b/Rlog/View/Components/BorderedTextField.swift
@@ -88,7 +88,7 @@ private extension BorderedTextField {
     func isErrorOnTextField() -> Color {
         switch textFieldType {
         case .workplace:
-            if text.count == 20 { return .red }
+            if text.count > 20 { return .red }
         case .wage:
             if text == "" { return .primary }
             guard let textToInt = Int(text) else { return .red }

--- a/Rlog/View/WorkSpace/WorkspaceCreateView.swift
+++ b/Rlog/View/WorkSpace/WorkspaceCreateView.swift
@@ -1,5 +1,5 @@
 //
-//  WorkSpaceCreateView.swift
+//  WorkspaceCreateView.swift
 //  Rlog
 //
 //  Created by 송시원 on 2022/10/17.
@@ -39,7 +39,7 @@ struct WorkspaceCreateView: View {
                     NavigationLink {
                         WorkspaceCreateScheduleListView(
                             isActiveNavigation: $viewModel.isActiveNavigation, workspaceModel: WorkSpaceModel(
-                                name: viewModel.workSpace,
+                                name: viewModel.workspace,
                                 paymentDay: viewModel.payday,
                                 hourlyWage: viewModel.hourlyWage,
                                 hasTax: viewModel.hasTax,
@@ -55,7 +55,7 @@ struct WorkspaceCreateView: View {
         }
         .onAppear {
           DispatchQueue.main.asyncAfter(deadline: .now() + 0.75) {
-              self.checkoutInFocus = .workSpace
+              self.checkoutInFocus = .workspace
           }
         }
     }
@@ -108,8 +108,8 @@ private extension WorkspaceCreateView {
     }
     
     var workspace: some View {
-        InputFormElement(containerType: .workplace, text: $viewModel.workSpace)
-            .focused($checkoutInFocus, equals: .workSpace)
+        InputFormElement(containerType: .workplace, text: $viewModel.workspace)
+            .focused($checkoutInFocus, equals: .workspace)
             .onSubmit {
                 viewModel.didTapConfirmButton()
             }
@@ -123,7 +123,7 @@ private extension WorkspaceCreateView {
                 switch checkoutInFocus {
                 case .none:
                     break
-                case .some(.workSpace):
+                case .some(.workspace):
                     checkoutInFocus = .hourlyWage
                     break
                 case .some(.hourlyWage):

--- a/Rlog/View/WorkSpace/WorkspaceCreateView.swift
+++ b/Rlog/View/WorkSpace/WorkspaceCreateView.swift
@@ -96,6 +96,9 @@ private extension WorkspaceCreateView {
         if !viewModel.isHiddenPayday {
             InputFormElement(containerType: .payday, text: $viewModel.payday)
                 .focused($checkoutInFocus, equals: .payday)
+                .onChange(of: viewModel.payday) { newValue in
+                    viewModel.checkErrorOfInputText(type: .payday, newValue)
+                }
         }
     }
     
@@ -104,14 +107,18 @@ private extension WorkspaceCreateView {
         if !viewModel.isHiddenHourlyWage {
             InputFormElement(containerType: .wage, text: $viewModel.hourlyWage)
                 .focused($checkoutInFocus, equals: .hourlyWage)
+                .onChange(of: viewModel.hourlyWage) { newValue in
+                    viewModel.checkErrorOfInputText(type: .hourlyWage, newValue)
+                }
         }
     }
     
     var workspace: some View {
         InputFormElement(containerType: .workplace, text: $viewModel.workspace)
             .focused($checkoutInFocus, equals: .workspace)
-            .onSubmit {
-                viewModel.didTapConfirmButton()
+            .onSubmit { viewModel.didTapConfirmButton() }
+            .onChange(of: viewModel.workspace) { newValue in
+                viewModel.checkErrorOfInputText(type: .workspace, newValue)
             }
     }
     

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceCreateViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceCreateViewModel.swift
@@ -23,51 +23,11 @@ final class WorkspaceCreateViewModel: ObservableObject {
     @Published var isHiddenHourlyWage: Bool = true
     var isHiddenConfirmButton: Bool = false
     var isHiddenToolBarItem: Bool = true
+    var textLimited = ""
     
-    @Published var workspace = "" {
-        didSet {
-            if workspace.isEmpty  {
-                inActivateButton()
-            } else {
-                if workspace.count >= 21 { workspace = oldValue }
-                if workspace.count >= 20 {
-                    inActivateButton()
-                } else {
-                    activateButton()
-                }
-            }
-        }
-    }
-    @Published var hourlyWage = "" {
-        didSet {
-            if hourlyWage.isEmpty {
-                inActivateButton()
-            } else {
-                guard let textToInt = Int(hourlyWage) else { return hourlyWage = "" }
-                if textToInt  >= 10000000 { hourlyWage = oldValue }
-                if textToInt >= 1000000 {
-                    inActivateButton()
-                } else {
-                    activateButton()
-                }
-            }
-        }
-    }
-    @Published var payday = "" {
-        didSet {
-            if payday.isEmpty {
-                inActivateButton()
-            } else {
-                guard let textToInt = Int(payday) else { return payday = "" }
-                if textToInt > 289 {payday = oldValue}
-                if textToInt > 28 {
-                    inActivateButton()
-                } else {
-                    activateButton()
-                }
-            }
-        }
-    }
+    @Published var workspace = ""
+    @Published var hourlyWage = ""
+    @Published var payday = ""
     @Published var hasTax: Bool = false
     @Published var hasJuhyu: Bool = false
     
@@ -141,6 +101,46 @@ private extension WorkspaceCreateViewModel {
             isHiddenToolBarItem = false
             return
         }
+    }
+}
+
+extension WorkspaceCreateViewModel {
+    func checkErrorOfInputText(type: WritingState, _ text: String) {
+        switch type {
+        case .workspace:
+            if text.isEmpty { inActivateButton() }
+            else { activateButton() }
+            if text.count == 20 { textLimited = text }
+            if text.count >= 20 {
+                workspace = textLimited
+                inActivateButton()
+            }
+        case .hourlyWage:
+            if text.isEmpty { inActivateButton() }
+            guard let textToInt = Int(text) else { return self.hourlyWage = "" }
+            
+            if textToInt > 1000000 && text.count < 8 { textLimited = text }
+            if textToInt  >= 1000000 {
+                hourlyWage = textLimited
+                inActivateButton()
+            } else {
+                activateButton()
+            }
+        case .payday:
+            if text.isEmpty { inActivateButton() }
+            guard let textToInt = Int(text) else { return self.payday = "" }
+            
+            if textToInt > 28 && text.count <= 3 { textLimited = text }
+            if textToInt > 28 {
+                payday = textLimited
+                inActivateButton()
+            } else {
+                activateButton()
+            }
+        case .toggleOptions:
+            return
+        }
+
     }
 }
 

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceCreateViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceCreateViewModel.swift
@@ -15,7 +15,7 @@ final class WorkspaceCreateViewModel: ObservableObject {
         self._isActiveNavigation = isActiveNavigation
     }
     
-    var currentState: WritingState = .workSpace
+    var currentState: WritingState = .workspace
     var isActivatedConfirmButton: Bool = false
     
     @Published var isHiddenToggleInputs: Bool = true
@@ -24,13 +24,13 @@ final class WorkspaceCreateViewModel: ObservableObject {
     var isHiddenConfirmButton: Bool = false
     var isHiddenToolBarItem: Bool = true
     
-    @Published var workSpace = "" {
+    @Published var workspace = "" {
         didSet {
-            if workSpace.isEmpty  {
+            if workspace.isEmpty  {
                 inActivateButton()
             } else {
-                if workSpace.count >= 21 { workSpace = oldValue }
-                if workSpace.count >= 20 {
+                if workspace.count >= 21 { workspace = oldValue }
+                if workspace.count >= 20 {
                     inActivateButton()
                 } else {
                     activateButton()
@@ -83,7 +83,7 @@ private extension WorkspaceCreateViewModel {
     func switchToNextStatus() {
         withAnimation(.easeIn) {
             switch currentState {
-            case .workSpace:
+            case .workspace:
                 isHiddenHourlyWage = false
                 currentState = .hourlyWage
             case .hourlyWage:
@@ -110,18 +110,18 @@ private extension WorkspaceCreateViewModel {
     
     func activateButton()  {
         switch currentState {
-        case .workSpace:
+        case .workspace:
             isActivatedConfirmButton = true
             return
         case .hourlyWage:
-            if workSpace.isEmpty {return}
+            if workspace.isEmpty {return}
             if hourlyWage.isEmpty {return}
             guard let hourlyWageInt = Int(hourlyWage) else { return }
             if hourlyWageInt >= 1000000 {return}
             isActivatedConfirmButton = true
             return
         case .payday:
-            if workSpace.isEmpty {return}
+            if workspace.isEmpty {return}
             if hourlyWage.isEmpty {return}
             guard let hourlyWageInt = Int(hourlyWage) else { return }
             if hourlyWageInt >= 1000000 {return}
@@ -131,7 +131,7 @@ private extension WorkspaceCreateViewModel {
             isActivatedConfirmButton = true
             return
         case .toggleOptions:
-            if workSpace.isEmpty {return}
+            if workspace.isEmpty {return}
             if hourlyWage.isEmpty {return}
             guard let hourlyWageInt = Int(hourlyWage) else { return }
             if hourlyWageInt >= 1000000 {return}
@@ -145,14 +145,14 @@ private extension WorkspaceCreateViewModel {
 }
 
 enum WritingState: Hashable {
-    case workSpace
+    case workspace
     case hourlyWage
     case payday
     case toggleOptions
     
     var title: String {
         switch self {
-        case .workSpace:
+        case .workspace:
             return "근무지를 입력해주세요."
         case .hourlyWage:
             return "시급을 입력해주세요."


### PR DESCRIPTION
# 프로젝트 이미지 
<img src="https://user-images.githubusercontent.com/88080251/204258403-0f97230b-e097-460a-866a-4f9e736e568e.png" width="250"/>

## 세부 사항
- iOS 15.0 버젼 상에서 didSet이 작동하지 않던 버그를 해결하기 위해 onChange를 통해 예외 처리를 진행했습니다.

## 기타 질문 및 특이 사항
- 근무지명을 예로, 20자를 다 채워서 에러 메세지를 띄운 후 (버튼이 회색으로 변함) 다시 한 글자를 지워 19자를 만들면 버튼 색 또한 다시 초록색으로 변하는 것이 옳으나 즉각적으로 변하지 않더라고요,, 18자 까지 지워야 다시 돌아오는.. 👀... 왜 그런거죠?
 
## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)
- [x]  필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x]  코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x]  제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x]  본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
