### PR TITLE
BD-249 주휴수당 소득세 UI 순서바꾸기

### DIFF
--- a/Rlog/View/WorkSpace/WorkspaceCreateView.swift
+++ b/Rlog/View/WorkSpace/WorkspaceCreateView.swift
@@ -71,18 +71,18 @@ private extension WorkspaceCreateView {
     var toggle: some View {
         if !viewModel.isHiddenToggleInputs {
             VStack(spacing: 24) {
-                Toggle(isOn: $viewModel.hasTax, label: {
-                    HStack {
-                        Text("소득세")
-                        Text("3.3% 적용")
-                            .font(.caption)
-                    }
-                    .foregroundColor(.grayMedium)
-                })
                 Toggle(isOn: $viewModel.hasJuhyu, label: {
                     HStack {
                         Text("주휴수당")
                         Text("60시간 근무 시 적용")
+                            .font(.caption)
+                    }
+                    .foregroundColor(.grayMedium)
+                })
+                Toggle(isOn: $viewModel.hasTax, label: {
+                    HStack {
+                        Text("소득세")
+                        Text("3.3% 적용")
                             .font(.caption)
                     }
                     .foregroundColor(.grayMedium)

--- a/Rlog/View/WorkSpace/WorkspaceDetailView.swift
+++ b/Rlog/View/WorkSpace/WorkspaceDetailView.swift
@@ -146,8 +146,8 @@ private extension WorkspaceDetailView {
 }
 
 fileprivate enum WorkspaceDetailInfo: CaseIterable {
-    case hasTax
     case hasJuhyu
+    case hasTax
     
     var text: (title: String, description: String) {
         switch self {


### PR DESCRIPTION
# 프로젝트 이미지 
(수정 및 구현 사항에 대한 간략한 캡쳐)
|수정시|생성시|
|---|---|
|![image](https://user-images.githubusercontent.com/46256034/204471561-7fbb7b14-5554-473a-90e0-ff5ff88ff5c8.png)|![image](https://user-images.githubusercontent.com/46256034/204471750-d35b6048-3c13-4f5b-b296-2a987e04f606.png)|


## 세부 사항
(여기에 수정 사항에 대한 자세한 내용을 작성해 주세요.)
- 주휴수당과 소득세에대한 토글버튼의 배치 순서를 바꾸었습니다.

## 기타 질문 및 특이 사항
(궁금한 사항들, 하면서 느낀 점 및 공유할 내용)
- 기존 디자인과 순서가 달라진것에 대한 합의를 했습니다.
 
## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)
- [x]  필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x]  코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x]  제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x]  본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
