### PR TITLE
Bd 251 뱃지 세팅, 시간에 따른 미확정 리스트 분류, 날짜별 sorting을 진행합니다.

### DIFF
--- a/Rlog/Assets.xcassets/Icons/calender.clock.imageset/Contents.json
+++ b/Rlog/Assets.xcassets/Icons/calender.clock.imageset/Contents.json
@@ -2,16 +2,7 @@
   "images" : [
     {
       "filename" : "calendar-clock.svg",
-      "idiom" : "universal",
-      "scale" : "1x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "2x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "3x"
+      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/Rlog/Assets.xcassets/Icons/coin.imageset/Contents.json
+++ b/Rlog/Assets.xcassets/Icons/coin.imageset/Contents.json
@@ -2,16 +2,7 @@
   "images" : [
     {
       "filename" : "coin.svg",
-      "idiom" : "universal",
-      "scale" : "1x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "2x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "3x"
+      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/Rlog/Assets.xcassets/Icons/inbox.curved.badge.imageset/Contents.json
+++ b/Rlog/Assets.xcassets/Icons/inbox.curved.badge.imageset/Contents.json
@@ -2,16 +2,7 @@
   "images" : [
     {
       "filename" : "Group 194.svg",
-      "idiom" : "universal",
-      "scale" : "1x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "2x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "3x"
+      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/Rlog/Assets.xcassets/Icons/inbox.curved.imageset/Contents.json
+++ b/Rlog/Assets.xcassets/Icons/inbox.curved.imageset/Contents.json
@@ -2,16 +2,7 @@
   "images" : [
     {
       "filename" : "inbox.svg",
-      "idiom" : "universal",
-      "scale" : "1x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "2x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "3x"
+      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/Rlog/Assets.xcassets/Icons/plus.curved.imageset/Contents.json
+++ b/Rlog/Assets.xcassets/Icons/plus.curved.imageset/Contents.json
@@ -2,16 +2,7 @@
   "images" : [
     {
       "filename" : "plus.svg",
-      "idiom" : "universal",
-      "scale" : "1x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "2x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "3x"
+      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/Rlog/Assets.xcassets/Icons/suitcase.imageset/Contents.json
+++ b/Rlog/Assets.xcassets/Icons/suitcase.imageset/Contents.json
@@ -2,16 +2,7 @@
   "images" : [
     {
       "filename" : "suitcase.svg",
-      "idiom" : "universal",
-      "scale" : "1x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "2x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "3x"
+      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/Rlog/Manager/TimeManager.swift
+++ b/Rlog/Manager/TimeManager.swift
@@ -125,5 +125,14 @@ final class TimeManager {
         return minute
     }
     
+    func compareDate(date1: Date, date2: Date, unit: Calendar.Component) -> Bool {
+        let order = NSCalendar.current.compare(date1, to: date2, toGranularity: unit)
+        switch order {
+        case .orderedAscending:
+            return true
+        default:
+            return false
+        }
+    }
     // ✅ BD-203
 }

--- a/Rlog/View/Schedule/ScheduleHasNotDoneListView.swift
+++ b/Rlog/View/Schedule/ScheduleHasNotDoneListView.swift
@@ -39,6 +39,7 @@ private extension ScheduleHasNotDoneListView {
         ForEach(0..<viewModel.sortedHasNotDoneWorkdays.count, id: \.self) { index in
             VStack(alignment: .leading, spacing: 0) {
                 if !viewModel.sortedHasNotDoneWorkdays[index].1.isEmpty {
+                    // 월, 일 날짜 표시
                     HStack(spacing: 0) {
                         Text("\(viewModel.sortedHasNotDoneWorkdays[index].0.monthInt)월 \(viewModel.sortedHasNotDoneWorkdays[index].0.dayInt)일")
                             .font(.caption)
@@ -47,6 +48,7 @@ private extension ScheduleHasNotDoneListView {
                     }
                     HDivider()
                         .padding(.bottom, 8)
+                    // 미확정 리스트
                     VStack(alignment: .leading, spacing: 16) {
                         ForEach(viewModel.sortedHasNotDoneWorkdays[index].1, id: \.self) { data in
                             ScheduleCell(of: data) {

--- a/Rlog/View/Schedule/ScheduleListView.swift
+++ b/Rlog/View/Schedule/ScheduleListView.swift
@@ -71,9 +71,20 @@ private extension ScheduleListView {
                 currentMonth: currentMonth
             )
             Spacer()
-            // inbox.curved.badge로 조건 처리하면 됩니다.
             Button{ isScheduleHasNotDoneListViewActive.toggle() } label: {
-                Image("inbox.curved")
+                if viewModel.hasHasNotDoneWorkdays {
+                    ZStack {
+                        Image("inbox.curved.badge")
+                        Circle()
+                            .foregroundColor(Color.primary)
+                            .frame(width: 5.5, height: 5.5)
+                            .padding(.bottom, 14)
+                            .padding(.leading, 12.4)
+                    }
+
+                } else {
+                    Image("inbox.curved")
+                }
             }
             .foregroundColor(.grayMedium)
             .padding(.trailing, 16)

--- a/Rlog/ViewModel/Schedule/ScheduleHasNotDoneListViewModel.swift
+++ b/Rlog/ViewModel/Schedule/ScheduleHasNotDoneListViewModel.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 final class ScheduleHasNotDoneListViewModel: ObservableObject {
+    let timeManager = TimeManager()
     @Published var sortedHasNotDoneWorkdays: [(Date, [WorkdayEntity])] = []
     @Published var hasNotDoneWorkdays: [WorkdayEntity] = [] {
         didSet {
@@ -17,6 +18,7 @@ final class ScheduleHasNotDoneListViewModel: ObservableObject {
     
     func onAppear() {
         getSortedHasNotDoneWorkdays()
+        print("🔥", sortedHasNotDoneWorkdays)
     }
 }
 
@@ -28,11 +30,17 @@ private extension ScheduleHasNotDoneListViewModel {
         
         let result = CoreDataManager.shared.getHasNotDoneWorkdays()
         let hasNotdoneWorkdaysBeforeToday = result.filter {
-            let date = $0.date.onlyDate ?? Date()
-            let today = Date().onlyDate ?? Date()
-            return date <= today
+            let date = $0.date
+            let endTime = $0.endTime
+            let today = Date()
+            let compareResult = timeManager.compareDate(date1: endTime, date2: today, unit: .minute)
+            
+            return date <= today && compareResult
         }
-        hasNotDoneWorkdays = hasNotdoneWorkdaysBeforeToday.uniqued()
+        
+        let filteredArray = hasNotdoneWorkdaysBeforeToday.uniqued()
+        
+        hasNotDoneWorkdays = filteredArray.sorted { $0.date < $1.date }
     }
     
     // 미확정 일정을 날짜 별로 분류합니다.

--- a/Rlog/ViewModel/Schedule/ScheduleListViewModel.swift
+++ b/Rlog/ViewModel/Schedule/ScheduleListViewModel.swift
@@ -10,6 +10,7 @@ import SwiftUI
 final class ScheduleListViewModel: ObservableObject {
     let calendar = Calendar.current
     let timeManager = TimeManager()
+    var hasHasNotDoneWorkdays = false
     @Published var workspaces: [WorkspaceEntity] = []
     @Published var workdays: (hasNotDone: [WorkdayEntity], hasDone: [WorkdayEntity]) = ([], [])
     @Published var workdaysOfFocusedDate: (hasNotDone: [WorkdayEntity], hasDone: [WorkdayEntity]) = ([], [])
@@ -28,10 +29,10 @@ final class ScheduleListViewModel: ObservableObject {
     }
     
     func onAppear() {
-        // 생성된 근무지 여부를 확인합니다. 생성된 근무지가 없다면 예외처리 화면을 표시합니다.
         getAllWorkspaces()
         getWorkdaysOfFiveMonths()
         getWorkdaysOfFocusDate()
+        detectHasNotDoneWorkdays()
     }
     
     func didScrollToNextWeek() {
@@ -125,6 +126,20 @@ private extension ScheduleListViewModel {
         let extractedDate = DateComponents(year: year, month: month, day: day)
         
         return calendar.date(from: extractedDate) ?? Date()
+    }
+    
+    func detectHasNotDoneWorkdays() {
+        let result = CoreDataManager.shared.getHasNotDoneWorkdays()
+        let hasNotdoneWorkdaysBeforeToday = result.filter {
+            let date = $0.date.onlyDate ?? Date()
+            let today = Date().onlyDate ?? Date()
+            return date <= today
+        }
+        if !hasNotdoneWorkdaysBeforeToday.uniqued().isEmpty {
+            self.hasHasNotDoneWorkdays = true
+        } else {
+            self.hasHasNotDoneWorkdays = false
+        }
     }
 }
 

--- a/Rlog/ViewModel/Schedule/ScheduleListViewModel.swift
+++ b/Rlog/ViewModel/Schedule/ScheduleListViewModel.swift
@@ -135,10 +135,10 @@ private extension ScheduleListViewModel {
             let today = Date().onlyDate ?? Date()
             return date <= today
         }
-        if !hasNotdoneWorkdaysBeforeToday.uniqued().isEmpty {
-            self.hasHasNotDoneWorkdays = true
-        } else {
+        if hasNotdoneWorkdaysBeforeToday.uniqued().isEmpty {
             self.hasHasNotDoneWorkdays = false
+        } else {
+            self.hasHasNotDoneWorkdays = true
         }
     }
 }


### PR DESCRIPTION
# 프로젝트 이미지 
<div>
<img src="https://user-images.githubusercontent.com/88080251/204735543-ef25e8b7-a698-44fc-9b6f-2e1ac0dea8d6.png" width="250"/>
<img src="https://user-images.githubusercontent.com/88080251/204735603-7e7b1c97-27a8-4f94-ad9d-dc92ba25258e.png" width="250"/>
</div>
🔥 시뮬레이터 날짜가 12월 10일임

## 세부 사항
- 미확정 일정이 있을 경우 해당 뷰 네비게이션 링크 버튼에 뱃지를 표시합니다.
- 아직 퇴근 전인데도 확정하기 버튼이 활성화 되어있는 경우를 개선했습니다.
- 미확정 일정을 날짜별로 배치합니다.

## 기타 질문 및 특이 사항
- N/A
 
## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)
- [x]  필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x]  코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x]  제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x]  본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
