### PR TITLE
Bd 254 근무 종료시간이 시작시간보다 작은경우 익일 처리

### DIFF
--- a/Rlog/Manager/TimeManager.swift
+++ b/Rlog/Manager/TimeManager.swift
@@ -67,14 +67,26 @@ final class TimeManager {
     }
     
     func calculateTimeGap(startHour: Int16, startMinute: Int16, endHour: Int16, endMinute: Int16) -> Double? {
-        guard
-            let startTime = calendar.date(bySettingHour: Int(startHour), minute: Int(startMinute), second: 0, of: Date()),
-            let endTime = calendar.date(bySettingHour: Int(endHour), minute: Int(endMinute), second: 0, of: Date())
-        else { return nil }
-        
-        let gap = endTime - startTime
-        
-        return gap
+        if startHour < endHour {
+            guard
+                let startTime = calendar.date(bySettingHour: Int(startHour), minute: Int(startMinute), second: 0, of: Date()),
+                let endTime = calendar.date(bySettingHour: Int(endHour), minute: Int(endMinute), second: 0, of: Date())
+            else { return nil }
+            
+            let gap = endTime - startTime
+            
+            return gap
+        } else {
+            guard
+                let startTime = calendar.date(bySettingHour: Int(startHour), minute: Int(startMinute), second: 0, of: Date()),
+                let endTime = calendar.date(bySettingHour: Int(endHour), minute: Int(endMinute), second: 0, of: Date()),
+                let endTimePlus1Day = calendar.date(byAdding: DateComponents(day: 1), to: endTime)
+            else { return nil }
+            
+            let gap = endTimePlus1Day - startTime
+            
+            return gap
+        }
     }
 
     func calculateTimeGapBetweenTwoDate(start: Date, end: Date) -> Double {

--- a/Rlog/View/Components/ScheduleContainer.swift
+++ b/Rlog/View/Components/ScheduleContainer.swift
@@ -65,7 +65,7 @@ private extension ScheduleContainer {
     }
     
     var workHourView: some View {
-        HStack {
+        HStack(alignment: .top) {
             // 시간이 n시 0분인 경우 두 자릿수인 00으로 표시
             if startMinute < 30 {
                 Text("\(startHour):\(startMinute)0")
@@ -87,6 +87,13 @@ private extension ScheduleContainer {
                 Text("\(endHour):\(endMinute)")
                     .font(.body)
                     .foregroundColor(Color.fontBlack)
+            }
+            
+            if startHour >= endHour {
+                Text("+1")
+                    .font(.caption)
+                    .foregroundColor(.grayMedium)
+                    .padding(.leading, -6)
             }
         }
     }

--- a/Rlog/View/MonthlyCalculate/MonthlyCalculateDetailView.swift
+++ b/Rlog/View/MonthlyCalculate/MonthlyCalculateDetailView.swift
@@ -230,6 +230,9 @@ private extension MonthlyCalculateDetailView {
         var endTime: String {
             return "\(viewModel.timeManager.getHour(workday.endTime)):\(viewModel.timeManager.getMinute(workday.endTime) >= 10 ? viewModel.timeManager.getMinute(workday.endTime).description : "0\(viewModel.timeManager.getMinute(workday.endTime))")"
         }
+        var isShowPlus1: Bool {
+            return workday.startTime.dayInt != workday.endTime.dayInt
+        }
         
         return VStack(alignment: .leading, spacing: 0) {
             HStack {
@@ -247,11 +250,16 @@ private extension MonthlyCalculateDetailView {
             }
             .padding(.top)
             
-            HStack {
+            HStack(alignment: .top, spacing: 2) {
                 Text("\(workday.date.monthInt)월 \(workday.date.dayInt)일")
                     .fontWeight(.bold)
                 Spacer()
                 Text("\(startTime) ~ \(endTime)")
+                if isShowPlus1 {
+                    Text("+1")
+                        .font(.caption)
+                        .foregroundColor(Color.grayMedium)
+                }
             }
             .foregroundColor(Color.fontBlack)
             .padding(EdgeInsets(top: 8, leading: 0, bottom: 16, trailing: 0))

--- a/Rlog/View/Schedule/ScheduleCell.swift
+++ b/Rlog/View/Schedule/ScheduleCell.swift
@@ -40,7 +40,7 @@ private extension ScheduleCell {
                     .foregroundColor(viewModel.data.hasDone ? Color.grayLight : Color.fontBlack)
             }
             
-            HStack {
+            HStack(alignment: .top, spacing: 2) {
                 Text("\(viewModel.data.workspace.name)")
                     .font(.body)
                     .fontWeight(.bold)
@@ -51,6 +51,11 @@ private extension ScheduleCell {
                 Text("\(viewModel.startTimeString) ~ \(viewModel.endTimeString)")
                     .font(.body)
                     .foregroundColor(viewModel.data.hasDone ? Color.grayLight : Color.fontBlack)
+                if viewModel.isShowPlus1 {
+                    Text("+1")
+                        .font(.caption)
+                        .foregroundColor(viewModel.data.hasDone ? Color.grayLight : Color.grayMedium)
+                }
             }
             .padding(.vertical, 8)
             

--- a/Rlog/View/WorkSpace/SubViews/WorkSpaceCell.swift
+++ b/Rlog/View/WorkSpace/SubViews/WorkSpaceCell.swift
@@ -87,9 +87,21 @@ private extension WorkspaceCell {
                         }
                         .padding(.trailing, 3)
                         
-                        Text("\(schedule.startHour):\(schedule.startMinute < 30 ? "00" : "30") - \(schedule.endHour):\(schedule.endMinute < 30 ? "00" : "30")")
+                        HStack(alignment: .top, spacing: 0) {
+                            Group {
+                                Text("\(schedule.startHour):\(schedule.startMinute < 30 ? "00" : "30") - ")
+                                Text("\(schedule.endHour):\(schedule.endMinute < 30 ? "00" : "30")")
+                            }
                             .font(.subheadline)
                             .foregroundColor(.fontBlack)
+                            
+                            if schedule.startHour >= schedule.endHour {
+                                Text("+1")
+                                    .font(.caption)
+                                    .foregroundColor(Color.grayMedium)
+                                    .padding(.leading, 2)
+                            }
+                        }
                     }
                 }
             }

--- a/Rlog/ViewModel/MainTabViewModel.swift
+++ b/Rlog/ViewModel/MainTabViewModel.swift
@@ -41,8 +41,12 @@ private extension MainTabViewModel {
                     while range < after1MonthOfLatestDate {
                         if schedule.repeatDays.contains(range.fetchDayOfWeek(date: range)) {
                             guard let startTime = Calendar.current.date(bySettingHour: Int(schedule.startHour), minute: Int(schedule.startMinute), second: 0, of: range),
-                                  let endTime = Calendar.current.date(bySettingHour: Int(schedule.endHour), minute: Int(schedule.endMinute), second: 0, of: range),
+                                  var endTime = Calendar.current.date(bySettingHour: Int(schedule.endHour), minute: Int(schedule.endMinute), second: 0, of: range),
                                   let date = range.onlyDate else { return }
+                            
+                            if startTime >= endTime {
+                                endTime = Calendar.current.date(byAdding: DateComponents(day: 1), to: endTime) ?? endTime
+                            }
 
                             CoreDataManager.shared.createWorkday(
                                 of: workspace,

--- a/Rlog/ViewModel/Schedule/ScheduleCellViewModel.swift
+++ b/Rlog/ViewModel/Schedule/ScheduleCellViewModel.swift
@@ -17,6 +17,9 @@ final class ScheduleCellViewModel: ObservableObject{
     @Published var startTimeString = ""
     @Published var endTimeString = ""
     @Published var hasDone = false
+    var isShowPlus1: Bool {
+        return data.startTime.dayInt != data.endTime.dayInt
+    }
     
     init(of data: WorkdayEntity, didTapConfirm: @escaping () -> Void) {
         self.data = data

--- a/Rlog/ViewModel/Schedule/ScheduleCreationViewModel.swift
+++ b/Rlog/ViewModel/Schedule/ScheduleCreationViewModel.swift
@@ -124,7 +124,13 @@ private extension ScheduleCreationViewModel {
     }
     
     func checkConflict() -> Bool {
+        let startTime = startTime
+        var endTime = endTime
         var isNotConflict = true
+        
+        if startTime >= endTime {
+            endTime = Calendar.current.date(byAdding: DateComponents(day: 1), to: endTime) ?? endTime
+        }
         
         for workday in alreadyExistWorkdays {
             if workday.startTime <= startTime && endTime <= workday.endTime {

--- a/Rlog/ViewModel/Schedule/ScheduleCreationViewModel.swift
+++ b/Rlog/ViewModel/Schedule/ScheduleCreationViewModel.swift
@@ -106,6 +106,11 @@ private extension ScheduleCreationViewModel {
     func createWorkday() {
         guard let workspaceEntity = selectedWorkspace else { return }
         guard let date = workday.onlyDate else { return }
+        
+        if startTime >= endTime {
+            endTime = Calendar.current.date(byAdding: DateComponents(day: 1), to: endTime) ?? endTime
+        }
+        
         CoreDataManager.shared.createWorkday(
             of: workspaceEntity,
             hourlyWage: workspaceEntity.hourlyWage,

--- a/Rlog/ViewModel/Schedule/ScheduleUpdateViewModel.swift
+++ b/Rlog/ViewModel/Schedule/ScheduleUpdateViewModel.swift
@@ -83,6 +83,10 @@ final class ScheduleUpdateViewModel: ObservableObject {
 
 private extension ScheduleUpdateViewModel {
     func updateWorkday() async {
+        if startTime >= endTime {
+            endTime = Calendar.current.date(byAdding: DateComponents(day: 1), to: endTime) ?? endTime
+        }
+        
         CoreDataManager.shared.editWorkday(
             of: workday,
             startTime: startTime,

--- a/Rlog/ViewModel/Schedule/ScheduleUpdateViewModel.swift
+++ b/Rlog/ViewModel/Schedule/ScheduleUpdateViewModel.swift
@@ -61,7 +61,13 @@ final class ScheduleUpdateViewModel: ObservableObject {
     }
     
     func checkConflict() -> Bool {
+        let startTime = startTime
+        var endTime = endTime
         var isNotConflict = true
+        
+        if startTime >= endTime {
+            endTime = Calendar.current.date(byAdding: DateComponents(day: 1), to: endTime) ?? endTime
+        }
         
         for workday in alreadyExistWorkdays {
             if workday.startTime <= startTime && endTime <= workday.endTime {

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceCreateConfirmationViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceCreateConfirmationViewModel.swift
@@ -94,8 +94,12 @@ private extension WorkspaceCreateConfirmationViewModel {
         while range < after5Month {
             if schedule.repeatDays.contains(range.fetchDayOfWeek(date: range)) {
                 guard let startTime = Calendar.current.date(bySettingHour: Int(schedule.startHour), minute: Int(schedule.startMinute), second: 0, of: range),
-                      let endTime = Calendar.current.date(bySettingHour: Int(schedule.endHour), minute: Int(schedule.endMinute), second: 0, of: range),
+                      var endTime = Calendar.current.date(bySettingHour: Int(schedule.endHour), minute: Int(schedule.endMinute), second: 0, of: range),
                       let date = range.onlyDate else { return }
+                
+                if startTime >= endTime {
+                    endTime = Calendar.current.date(byAdding: DateComponents(day: 1), to: endTime) ?? endTime
+                }
                 
                 CoreDataManager.shared.createWorkday(
                     of: workspace,

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceCreateCreatingScheduleViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceCreateCreatingScheduleViewModel.swift
@@ -110,11 +110,10 @@ private extension WorkspaceCreateCreatingScheduleViewModel {
     }
     
     func checkScheduleConflict(creatSchedules: [ScheduleModel]) -> Bool {
-        for i in 0..<creatSchedules.count {
-            for j in i..<creatSchedules.count {
-                for day in creatSchedules[i].repeatedSchedule {
-                    if creatSchedules[j].repeatedSchedule.contains(day) {
-                        print(day)
+        for creatSchedule in creatSchedules {
+            for day in sevenDays {
+                if day.isSelected {
+                    if creatSchedule.repeatedSchedule.contains(day.dayName) {
                         return true
                     }
                 }

--- a/Rlog/ViewModel/WorkSpace/WorkSpaceDetailViewModel.swift
+++ b/Rlog/ViewModel/WorkSpace/WorkSpaceDetailViewModel.swift
@@ -121,8 +121,12 @@ private extension WorkspaceDetailViewModel {
         while range < after5Month {
             if schedule.repeatDays.contains(range.fetchDayOfWeek(date: range)) {
                 guard let startTime = Calendar.current.date(bySettingHour: Int(schedule.startHour), minute: Int(schedule.startMinute), second: 0, of: range),
-                      let endTime = Calendar.current.date(bySettingHour: Int(schedule.endHour), minute: Int(schedule.endMinute), second: 0, of: range),
+                      var endTime = Calendar.current.date(bySettingHour: Int(schedule.endHour), minute: Int(schedule.endMinute), second: 0, of: range),
                       let date = range.onlyDate else { return }
+                
+                if startTime >= endTime {
+                    endTime = Calendar.current.date(byAdding: DateComponents(day: 1), to: endTime) ?? endTime
+                }
                 
                 CoreDataManager.shared.createWorkday(
                     of: workspace,


### PR DESCRIPTION
# 프로젝트 이미지 
(수정 및 구현 사항에 대한 간략한 캡쳐)

<div>
<img src=https://user-images.githubusercontent.com/103025692/204741783-0bbace30-051a-4b49-8896-8a77cd720b97.png width=200 />
<img src=https://user-images.githubusercontent.com/103025692/204741791-a0daeb58-615f-45d3-a2d3-df410061de05.png width=200 />
<img src=https://user-images.githubusercontent.com/103025692/204741794-5e373c4b-e97b-4c7a-85f9-ac0bd5333e44.png width=200 />
</div>

## 세부 사항
(여기에 수정 사항에 대한 자세한 내용을 작성해 주세요.)
- 새벽 근무 대응을 추가했습니다.
- Workday가 startTime이 endTime보다 클 경우에 Day를 +1해서 저장시켰습니다.
- dayInt가 다를 경우 +1이 뜨게 했습니다.
- 근무지 추가 시에 근무 패턴 확인 로직을 수정했습니다.

## 기타 질문 및 특이 사항
(궁금한 사항들, 하면서 느낀 점 및 공유할 내용)
- 로직에 이상이 없는지 확인이 필요합니다.
 
## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)
- [x]  필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x]  코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x]  제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x]  본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
